### PR TITLE
Implement Travis CI for running tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,12 @@
-language: bash
+language: c
+
+services:
+  - docker
 
 script:
+  - docker build -t ci -f .travis/Dockerfile .
+  - docker run -w /repo -v $(pwd):/repo -it ci .travis/run.sh
+
+after_script:
   - bin/fetch-configlet
   - bin/configlet lint --track-id tcl .

--- a/.travis/Dockerfile
+++ b/.travis/Dockerfile
@@ -1,0 +1,6 @@
+FROM efrecon/tcl
+
+ENTRYPOINT ["sh"]
+
+RUN apt-get update
+RUN apt-get install -y git

--- a/.travis/run.sh
+++ b/.travis/run.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+set -e
+
+echo "*** Test all exercises:"
+echo
+
+cd /repo/exercises
+for exercise in *; do
+    echo " - $exercise:"
+    cd "$exercise"
+    cp example.tcl "$exercise.tcl"
+    tclsh "test.tcl"
+    echo
+    git checkout "$exercise.tcl"
+    cd ..
+done


### PR DESCRIPTION
This addresses #2.

This commit adds Travis CI configuration for setting up CI using Docker. We rely on the `efrecon/docker-tcl` Docker image that bootstraps TCL 8.6 in Ubuntu.

For now, CI testing fails fast.

This commit makes assumptions about the file layout of exercises and their tests that have not been decided or documented yet.