### PR TITLE
Make 'hello-world' and 'two-fer' fail fast.

### DIFF
--- a/exercises/hello-world/test.tcl
+++ b/exercises/hello-world/test.tcl
@@ -23,6 +23,12 @@ if {[fail_fast]} {
     }
 }
 
+proc cleanupTests {} {
+    set failed [failed]
+    uplevel 1 ::tcltest::cleanupTests
+    if {$failed} {exit 1}
+}
+
 if {$::argv0 eq [info script]} {
     test hello_Hello {
         Test: [hello] == "Hello, World!"
@@ -30,7 +36,5 @@ if {$::argv0 eq [info script]} {
         hello
     } -result "Hello, World!"
 
-    set failed [failed]
     cleanupTests
-    if {$failed} {exit 1}
 }

--- a/exercises/hello-world/test.tcl
+++ b/exercises/hello-world/test.tcl
@@ -4,12 +4,21 @@ package require tcltest
 namespace import ::tcltest::*
 source "hello-world.tcl"
 
-proc test args {
-    if {$::tcltest::numTests(Failed) > 0} {
-        puts "**** Exit on first failure"
-        exit 1
+proc fail_fast {} {
+    return [expr {
+        ![info exists ::env(RUN_ALL)]
+        || [string is boolean -strict $::env(RUN_ALL)]
+        && !$::env(RUN_ALL)
+    }]
+}
+
+if {[fail_fast]} {
+    proc test args {
+        if {$::tcltest::numTests(Failed) > 0} {
+            ::tcltest::configure -skip *
+        }
+        uplevel [list ::tcltest::test {*}$args]
     }
-    uplevel [list ::tcltest::test {*}$args]
 }
 
 if {$::argv0 eq [info script]} {

--- a/exercises/hello-world/test.tcl
+++ b/exercises/hello-world/test.tcl
@@ -12,11 +12,13 @@ proc fail_fast {} {
     }]
 }
 
+proc failed {} {
+    return [expr {$::tcltest::numTests(Failed) > 0}]
+}
+
 if {[fail_fast]} {
     proc test args {
-        if {$::tcltest::numTests(Failed) > 0} {
-            ::tcltest::configure -skip *
-        }
+        if {[failed]} {::tcltest::configure -skip *}
         uplevel [list ::tcltest::test {*}$args]
     }
 }
@@ -28,5 +30,7 @@ if {$::argv0 eq [info script]} {
         hello
     } -result "Hello, World!"
 
+    set failed [failed]
     cleanupTests
+    if {$failed} {exit 1}
 }

--- a/exercises/hello-world/test.tcl
+++ b/exercises/hello-world/test.tcl
@@ -4,6 +4,14 @@ package require tcltest
 namespace import ::tcltest::*
 source "hello-world.tcl"
 
+proc test args {
+    if {$::tcltest::numTests(Failed) > 0} {
+        puts "**** Exit on first failure"
+        exit 1
+    }
+    uplevel [list ::tcltest::test {*}$args]
+}
+
 if {$::argv0 eq [info script]} {
     test hello_Hello {
         Test: [hello] == "Hello, World!"

--- a/exercises/two-fer/test.tcl
+++ b/exercises/two-fer/test.tcl
@@ -4,6 +4,14 @@ package require tcltest
 namespace import ::tcltest::*
 source "two-fer.tcl"
 
+proc test args {
+    if {$::tcltest::numTests(Failed) > 0} {
+        puts "**** Exit on first failure"
+        exit 1
+    }
+    uplevel [list ::tcltest::test {*}$args]
+}
+
 if {$::argv0 eq [info script]} {
 
     test two-fer-1 {

--- a/exercises/two-fer/test.tcl
+++ b/exercises/two-fer/test.tcl
@@ -23,6 +23,12 @@ if {[fail_fast]} {
     }
 }
 
+proc cleanupTests {} {
+    set failed [failed]
+    uplevel 1 ::tcltest::cleanupTests
+    if {$failed} {exit 1}
+}
+
 if {$::argv0 eq [info script]} {
 
     test two-fer-1 {
@@ -43,7 +49,5 @@ if {$::argv0 eq [info script]} {
         two-fer "Bob"
     } -result "One for Bob, one for me."
 
-    set failed [failed]
     cleanupTests
-    if {$failed} {exit 1}
 }

--- a/exercises/two-fer/test.tcl
+++ b/exercises/two-fer/test.tcl
@@ -12,11 +12,13 @@ proc fail_fast {} {
     }]
 }
 
+proc failed {} {
+    return [expr {$::tcltest::numTests(Failed) > 0}]
+}
+
 if {[fail_fast]} {
     proc test args {
-        if {$::tcltest::numTests(Failed) > 0} {
-            ::tcltest::configure -skip *
-        }
+        if {[failed]} {::tcltest::configure -skip *}
         uplevel [list ::tcltest::test {*}$args]
     }
 }
@@ -41,5 +43,7 @@ if {$::argv0 eq [info script]} {
         two-fer "Bob"
     } -result "One for Bob, one for me."
 
+    set failed [failed]
     cleanupTests
+    if {$failed} {exit 1}
 }

--- a/exercises/two-fer/test.tcl
+++ b/exercises/two-fer/test.tcl
@@ -4,12 +4,21 @@ package require tcltest
 namespace import ::tcltest::*
 source "two-fer.tcl"
 
-proc test args {
-    if {$::tcltest::numTests(Failed) > 0} {
-        puts "**** Exit on first failure"
-        exit 1
+proc fail_fast {} {
+    return [expr {
+        ![info exists ::env(RUN_ALL)]
+        || [string is boolean -strict $::env(RUN_ALL)]
+        && !$::env(RUN_ALL)
+    }]
+}
+
+if {[fail_fast]} {
+    proc test args {
+        if {$::tcltest::numTests(Failed) > 0} {
+            ::tcltest::configure -skip *
+        }
+        uplevel [list ::tcltest::test {*}$args]
     }
-    uplevel [list ::tcltest::test {*}$args]
 }
 
 if {$::argv0 eq [info script]} {


### PR DESCRIPTION
As a follow-up to the TDD proposal of making tests fail fast in #11,
make the currently implemented exercises fail fast with this code.

This is shown to work in [this travis build](https://travis-ci.org/sshine/exercism-tcl/builds/569325997).