### PR TITLE
hello-world: Fix test naming

### DIFF
--- a/exercises/hello-world/test.tcl
+++ b/exercises/hello-world/test.tcl
@@ -5,8 +5,9 @@ namespace import ::tcltest::*
 source "hello-world.tcl"
 
 if {$::argv0 eq [info script]} {
-    test hello_Hello {
-        Test: [hello] == "Hello, World!"
+
+    test hello-1 {
+        Say Hi!
     } -body {
         hello
     } -result "Hello, World!"


### PR DESCRIPTION
Fix test naming according to #13.

This way our current two exercises are consistently generated.