### PR TITLE
CI sync test versions

### DIFF
--- a/.travis/run.sh
+++ b/.travis/run.sh
@@ -1,16 +1,4 @@
 #!/bin/sh
 set -e
 
-echo "*** Test all exercises:"
-echo
-
-cd /repo/exercises
-for exercise in *; do
-    echo " - $exercise:"
-    cd "$exercise"
-    cp example.tcl "$exercise.tcl"
-    tclsh "test.tcl"
-    echo
-    git checkout "$exercise.tcl"
-    cd ..
-done
+bin/test_all_exercises

--- a/.travis/run.sh
+++ b/.travis/run.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
-set -e
 
+bin/check_exercise_versions
 bin/test_all_exercises

--- a/bin/check_exercise_versions
+++ b/bin/check_exercise_versions
@@ -1,0 +1,54 @@
+#!/bin/sh
+set -e
+
+echo
+echo "*** Check exercise version numbers:"
+echo
+
+FAILED=0
+
+err() {
+    printf "\033[31m%s\n\033[0m" "$1"
+}
+
+cd exercises
+for exercise in *; do
+    cd "$exercise"
+
+    # Make sure each exercise has a .meta/version file.
+
+    if [ ! -e .meta/version ]; then
+        FAILED=1
+        err " - $exercise has no .meta/version file!"
+        cd ..
+        continue
+    fi
+
+    META_VERSION=$(cat .meta/version)
+    TEST_VERSION=$(echo 'source test.tcl; if {[info exists version]} {puts $version}' | tclsh)
+
+    # Make sure each exercise has a 'set version ...' statement.
+
+    if [ -z "$TEST_VERSION" ]; then
+        FAILED=1
+        err " - $exercise has no 'set version ...' statement!"
+        cd ..
+        continue
+    fi
+
+    # Make sure .meta/version is the same as 'set version ...'
+
+    if [ "$TEST_VERSION" != "$META_VERSION" ]; then
+        FAILED=1
+        err " - $exercise version mismatch: .meta/version = $META_VERSION, test.tcl = $TEST_VERSION!"
+        cd ..
+        continue
+    fi
+
+    echo " - $exercise has version $TEST_VERSION"
+    cd ..
+done
+
+if [ "$FAILED" -eq 1 ]; then
+    exit 1
+fi

--- a/bin/test_all_exercises
+++ b/bin/test_all_exercises
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+echo
+echo "*** Test all exercises:"
+echo
+
+cd exercises
+for exercise in *; do
+    echo " - $exercise:"
+    cd "$exercise"
+    cp example.tcl "$exercise.tcl"
+    tclsh "test.tcl"
+    echo
+    git checkout "$exercise.tcl"
+    cd ..
+done

--- a/exercises/hello-world/test.tcl
+++ b/exercises/hello-world/test.tcl
@@ -1,5 +1,5 @@
 #!/usr/bin/env tclsh
-set version 1.1.0.0
+set version 1.1.0
 package require tcltest
 namespace import ::tcltest::*
 source "hello-world.tcl"

--- a/exercises/two-fer/test.tcl
+++ b/exercises/two-fer/test.tcl
@@ -1,5 +1,5 @@
 #!/usr/bin/env tclsh
-set version 1.2.0.0
+set version 1.2.0
 package require tcltest
 namespace import ::tcltest::*
 source "two-fer.tcl"


### PR DESCRIPTION
This PR further addresses #2.

- CI: Move testing of all exercises to separate script: By separating each step of the CI run script into separate components, we can use those components manually before pushing as part of our workflow.

- `bin/check_exercise_versions`: Add a CI script that checks that `.meta/version` contains a version that is a prefix of `set version ...` in the test file for a given exercise. This ensures that exercise versions are in sync, since we have decided in #10 to keep the canonical version in `.meta/version` and an extra 4th component in the test file.

**TODO:** A CI script that fails if changes are made to test.tcl and 4th component isn't bumped. (I've been working on it, but it's not completely done yet.)