### PR TITLE
CI: Fix error message when .test file is missing

### DIFF
--- a/bin/check_exercise_versions
+++ b/bin/check_exercise_versions
@@ -25,6 +25,16 @@ for exercise in *; do
     fi
 
     META_VERSION=$(cat .meta/version)
+
+    # Make sure each exercise has a test.tcl file.
+
+    if [ ! -e "$exercise.test" ]; then
+        FAILED=1
+        err " - $exercise has no .test file!"
+        cd ..
+        continue
+    fi
+
     TEST_VERSION=$(echo "source $exercise.test; if {[info exists version]} {puts [set version]}" | tclsh)
 
     # Make sure each exercise has a 'set version ...' statement.

--- a/bin/test_all_exercises
+++ b/bin/test_all_exercises
@@ -4,13 +4,38 @@ echo
 echo "*** Test all exercises:"
 echo
 
+FAILED=0
+
+err() {
+    printf "\033[31m%s\n\033[0m" "$1"
+}
+
 cd exercises
 for exercise in *; do
-    echo " - $exercise:"
     cd "$exercise"
+
+    if [ ! -e example.tcl ]; then
+        FAILED=1
+        err " - $exercise: Missing example.tcl!"
+        cd ..
+        continue
+    fi
+
+    if [ ! -e "$exercise.test" ]; then
+        FAILED=1
+        err " - $exercise: Missing $exercise.test!"
+        cd ..
+        continue
+    fi
+
+    echo " - $exercise:"
     cp example.tcl "$exercise.tcl"
     tclsh "$exercise.test"
     echo
     git checkout "$exercise.tcl"
     cd ..
 done
+
+if [ "$FAILED" -eq 1 ]; then
+    exit 1
+fi


### PR DESCRIPTION
We assume that .test files exist, which causes the CI script to give strange rather than meaningful errors. During the migration from `test.tcl` to `$slug.text`, the following errors occurred:

     - hello-world has version 1.1.0
    couldn't read file "test.tcl": no such file or directory
     - leap has no 'set version ...' statement!

     - hello-world:
    test.tcl:	Total	1	Passed	1	Skipped	0	Failed	0

     - leap:
    couldn't read file "test.tcl": no such file or directory