### PR TITLE
update method for declaring instance variables

### DIFF
--- a/exercises/clock/example.tcl
+++ b/exercises/clock/example.tcl
@@ -1,29 +1,26 @@
 oo::class create Clock {
+    variable time
+
     constructor {hour minute} {
-        variable time
         set time [expr {60 * $hour + $minute}]
         my _normalize
     }
 
     # ensure the time is between 00:00 and 23:59
     method _normalize {} {
-        my variable time
         set time [expr {$time % (24 * 60)}]
         return
     }
 
     method time {} {
-        my variable time
         return $time
     }
 
     method toString {} {
-        my variable time
         return [format "%02d:%02d" [expr {$time / 60}] [expr {$time % 60}]]
     }
 
     method add {minutes} {
-        my variable time
         incr time $minutes
         my _normalize
         return [self]

--- a/exercises/high-scores/example.tcl
+++ b/exercises/high-scores/example.tcl
@@ -1,34 +1,31 @@
 #! tclsh
 
 oo::class create HighScores {
+    variable scores
+
     constructor {} {
-        variable scores [list]
+        set scores {}
     }
 
     method addScores {args} {
-        my variable scores
         lappend scores {*}$args
     }
 
     method scores {} {
-        my variable scores
         return $scores
     }
 
     method latest {} {
-        my variable scores
         return [lindex $scores end]
     }
     
     method personalBest {} {
-        my variable scores
         if {[llength $scores] > 0} {
             ::tcl::mathfunc::max {*}$scores
         }
     }
 
     method topThree {} {
-        my variable scores
         lrange [lsort -integer -decreasing $scores] 0 2
     }
 }

--- a/exercises/matrix/example.tcl
+++ b/exercises/matrix/example.tcl
@@ -1,16 +1,15 @@
 oo::class create Matrix {
+    variable rows
+
     constructor {inputString} {
-        variable rows
         set rows [lmap line [split $inputString \n] {split $line}]
     }
 
     method row {n} {
-        my variable rows
         return [lindex $rows $n-1]
     }
 
     method column {n} {
-        my variable rows
         return [lmap row $rows {lindex $row $n-1}]
     }
 }

--- a/exercises/tournament/example.tcl
+++ b/exercises/tournament/example.tcl
@@ -1,6 +1,5 @@
 oo::class create Tournament {
-    variable inputFile
-    variable results
+    variable inputFile results
 
     constructor {filename} {
         if {![file readable $filename]} {
@@ -13,7 +12,6 @@ oo::class create Tournament {
     # (only methods named [a-z]* are exported by default)
 
     method standings {} {
-        my variable results
         my Readfile
 
         set standings {}
@@ -37,7 +35,6 @@ oo::class create Tournament {
     # private
 
     method Readfile {} {
-        my variable inputFile results
         set results {}
         set fh [open $inputFile r]
 
@@ -69,7 +66,6 @@ oo::class create Tournament {
     }
 
     method Incr {team key} {
-        my variable results
         if {![dict exists $results $team]} {
             dict set results $team {w 0 l 0 d 0}
         }


### PR DESCRIPTION
Given Donal's response to https://stackoverflow.com/q/58071069/7552, update how class variables are declared: using the [`variable` command](https://tcl.tk/man/tcl8.6/TclCmd/define.htm#M19) in the defining body of `oo::class create` will update the variable resolution scope of `method`s to include the instance's namespace.