### PR TITLE
Enable Tcl track on website

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,7 +1,7 @@
 {
   "track_id": "tcl",
   "language": "Tcl",
-  "active": false,
+  "active": true,
   "blurb": "Tcl is a dynamic, open source programming language. It was designed with the goal of being very simple but powerful.",
   "ignore_pattern": "example",
   "solution_pattern": "example[.]tcl",


### PR DESCRIPTION
By setting

    "active": true

in config.json, this enables the track on Exercism.io.

@glennj: We can keep this PR hanging until we've merged the exercises you implemented.