### PR TITLE
Fix bin/fetch-configlet

### DIFF
--- a/bin/fetch-configlet
+++ b/bin/fetch-configlet
@@ -1,32 +1,62 @@
 #!/bin/bash
 
-LATEST=https://github.com/exercism/configlet/releases/latest
+set -eo pipefail
 
-OS=$(
-case $(uname) in
-    (Darwin*)
-        echo "mac";;
-    (Linux*)
-        echo "linux";;
-    (Windows*)
-        echo "windows";;
-    (*)
-        echo "linux";;
-esac)
+readonly RELEASES='https://github.com/exercism/configlet/releases'
 
-ARCH=$(
-case $(uname -m) in
-    (*64*)
-        echo 64bit;;
-    (*686*)
-        echo 32bit;;
-    (*386*)
-        echo 32bit;;
-    (*)
-        echo 64bit;;
-esac)
+get_version () {
+    curl --silent --head ${RELEASES}/latest  |
+    awk -v FS=/ -v RS='\r\n' 'tolower($1) ~ /location:/ {print $NF}'
+}
 
-VERSION="$(curl --head --silent $LATEST | awk -v FS=/ '/Location:/{print $NF}' | tr -d '\r')"
-URL=https://github.com/exercism/configlet/releases/download/$VERSION/configlet-$OS-${ARCH}.tgz
+case "$(uname)" in
+    (Darwin*)  OS='mac'     ;;
+    (Linux*)   OS='linux'   ;;
+    (Windows*) OS='windows' ;;
+    (MINGW*)   OS='windows' ;;
+    (*)        OS='linux'   ;;
+esac
 
-curl -s --location $URL | tar xz -C bin/
+case "$OS" in
+    (windows*) EXT='zip' ;;
+    (*)        EXT='tgz' ;;
+esac
+
+case "$(uname -m)" in
+    (*64*)  ARCH='64bit' ;;
+    (*686*) ARCH='32bit' ;;
+    (*386*) ARCH='32bit' ;;
+    (*)     ARCH='64bit' ;;
+esac
+
+
+VERSION="$(get_version)"
+URL="${RELEASES}/download/${VERSION}/configlet-${OS}-${ARCH}.${EXT}"
+localfile=bin/latest-configlet.${EXT}
+
+fetch_archive() {
+    local file_info=$1
+    for delay in {0..4}; do
+        sleep "$delay"
+        curl --silent --location "$URL" -o "$localfile"
+        if file "$localfile" 2>&1 | grep -q "$file_info"; then
+            # fetched successfully
+            return 0
+        fi
+    done
+    echo "Cannot fetch $URL" >&2
+    return 1
+}
+
+case "$EXT" in
+    zip)
+        fetch_archive "Zip archive data"
+        unzip "$localfile" -d bin/
+        ;;
+    tgz)
+        fetch_archive "gzip compressed data"
+        tar xzf "$localfile" -C bin/
+        ;;
+esac
+
+rm -f "$localfile"


### PR DESCRIPTION
This script has been broken for a while. Turns out the
`curl --head` call was getting the header field names in lower case.

I took this script from the bash track where I recently also added
retrying with delay up to 5 times before giving up.