### PR TITLE
bank-account exercise: Simplify the threading test.

### DIFF
--- a/exercises/bank-account/bank-account.test
+++ b/exercises/bank-account/bank-account.test
@@ -131,7 +131,7 @@ if {$::argv0 eq [info script]} {
 
     test bank-account-15 "adjust balance concurrently" -body {
         # In this style of using Tcl threads, we don't need
-        # to make any # thread-specific adjustments to the
+        # to make any thread-specific adjustments to the
         # BankAccount class: passing messages between threads
         # does all the locking for us transparently.
 
@@ -140,7 +140,6 @@ if {$::argv0 eq [info script]} {
         BankAccount create theAccount
         theAccount open
         theAccount deposit 123
-        set withdrawals 0
 
         # Create 1000 worker threads
         for {set i 0} {$i < 1000} {incr i} {
@@ -153,8 +152,9 @@ if {$::argv0 eq [info script]} {
                     after [expr {int(10 * rand())}]
                     thread::send -async $acctThread {
                         theAccount withdraw 5
-                        incr withdrawals
                     }
+                    # now that I've done the work, release me
+                    thread::release
                 }
                 thread::wait
             }]
@@ -167,14 +167,7 @@ if {$::argv0 eq [info script]} {
 
         # Reap them
         foreach thread $threads {
-            thread::release $thread
-        }
-
-        # Ensure all the messaging is complete:
-        # We expect the withdrawals variable to be written to 1000 times,
-        # once by each worker thread.
-        for {set i 0} {$i < 1000} {incr i} {
-            vwait withdrawals
+            thread::join $thread
         }
 
         theAccount balance


### PR DESCRIPTION
While working on the parallel-letter-frequency exercise, I realized
I could simplify how I reaped the worker threads.