### PR TITLE
rework binary-search-tree

### DIFF
--- a/exercises/binary-search-tree/binary-search-tree.test
+++ b/exercises/binary-search-tree/binary-search-tree.test
@@ -29,14 +29,33 @@ proc cleanupTests {} {
     if {$failed} {exit 1}
 }
 
-proc booleanMatch {expected actual} {
-    return [expr {
-        [string is boolean -strict $expected] &&
-        [string is boolean -strict $actual] &&
-        !!$expected == !!$actual
-    }]
+proc dictionaryMatch {expected actual} {
+    if {[dict size $expected] != [dict size $actual]} {
+        return false
+    }
+    dict for {key value} $expected {
+        if {![dict exists $actual $key]} {
+            return false
+        }
+        set actualValue [dict get $actual $key]
+
+        # if this value is a dict then recurse, 
+        # else just check for string equality
+        if {[string is list -strict $value] &&
+            [llength $value] > 1 && 
+            [llength $value] % 2 == 0
+        } {
+            set procname [lindex [info level 0] 0]
+            if {![$procname $value $actualValue]} {
+                return false
+            }
+        } elseif {$actualValue ne $value} {
+            return false
+        }
+    }
+    return true
 }
-customMatch boolean booleanMatch
+customMatch dictionary dictionaryMatch
 
 
 if {$::argv0 eq [info script]} {
@@ -44,61 +63,77 @@ if {$::argv0 eq [info script]} {
     test bst-1 "data is retained" -body {
         set b [BinarySearchTree new]
         $b insert 4
-        expr {
-            [$b data] == 4 &&
-            ![$b hasLeft] &&
-            ![$b hasRight]
-        }
-    } -returnCodes ok -match boolean -result true
+        $b toDict
+    } -returnCodes ok -match dictionary -result {
+        data 4 
+        left {} 
+        right {}
+    }
 
     test bst-2 "insert smaller number" -body {
         set b [BinarySearchTree new]
         $b insert 4
         $b insert 2
-        expr {
-            [$b data] == 4 &&
-            [[$b left] data] == 2 &&
-            ![$b hasRight]
+        $b toDict
+    } -returnCodes ok -match dictionary -result {
+        data 4
+        left {
+            data 2
+            left {}
+            right {}
         }
-    } -returnCodes ok -match boolean -result true
+        right {}
+    }
 
     test bst-3 "insert same number" -body {
         set b [BinarySearchTree new]
         $b insert 4
         $b insert 4
-        expr {
-            [$b data] == 4 &&
-            [[$b left] data] == 4 &&
-            ![$b hasRight]
+        $b toDict
+    } -returnCodes ok -match dictionary -result {
+        data 4
+        left {
+            data 4
+            left {}
+            right {}
         }
-    } -returnCodes ok -match boolean -result true
+        right {}
+    }
 
     test bst-4 "insert larger number" -body {
         set b [BinarySearchTree new]
         $b insert 4
         $b insert 5
-        expr {
-            [$b data] == 4 &&
-            [[$b right] data] == 5 &&
-            ![$b hasLeft]
+        $b toDict
+    } -returnCodes ok -match dictionary -result {
+        data 4
+        left {}
+        right {
+            data 5
+            left {}
+            right {}
         }
-    } -returnCodes ok -match boolean -result true
+    }
 
     test bst-5 "create complex tree" -body {
         set b [BinarySearchTree new]
         foreach n {4 2 6 1 3 5 7} {
             $b insert $n
         }
-        expr {
-            [$b data] == 4 &&
-            [[$b left] data] == 2 &&
-            [[[$b left] left] data] == 1 &&
-            [[[$b left] right] data] == 3 &&
-            [[$b right] data] == 6 &&
-            [[[$b right] left] data] == 5 &&
-            [[[$b right] right] data] == 7
+        $b toDict
+    } -returnCodes ok -match dictionary -result {
+        data 4
+        left {
+            data 2
+            left {data 1 left {} right {}}
+            right {data 3 left {} right {}}
         }
-    } -returnCodes ok -match boolean -result true
+        right {
+            data 6
+            left {data 5 left {} right {}}
+            right {data 7 left {} right {}}
+        }
+    }
 
     test bst-6 "can sort single number" -body {
         set b [BinarySearchTree new]

--- a/exercises/binary-search-tree/example.tcl
+++ b/exercises/binary-search-tree/example.tcl
@@ -4,51 +4,30 @@ oo::class create BinarySearchTree {
     variable right
 
     method data {} {
-        if {[info exists data]} {
-            return $data
-        }
-        return
-    }
-
-    method hasLeft {} {
-        return [info exists left]
-    }
-
-    method hasRight {} {
-        return [info exists right]
+        return [expr {[info exists data] ? $data : ""}]
     }
 
     method left {} {
-        if {[my hasLeft]} {
-            return $left
-        }
-        return
+        return [expr {[info exists left] ? $left : ""}]
     }
 
     method right {} {
-        if {[my hasRight]} {
-            return $right
-        }
-        return
+        return [expr {[info exists right] ? $right : ""}]
     }
 
     method insert {number} {
         if {![info exists data]} {
             set data $number
         } elseif {$number <= $data} {
-            if {[my hasLeft]} {
-                tailcall $left insert $number
-            } else {
+            if {![info exists left]} {
                 set left [[self class] new]
-                $left insert $number
             }
+            tailcall $left insert $number
         } else {
-            if {[my hasRight]} {
-                tailcall $right insert $number
-            } else {
+            if {![info exists right]} {
                 set right [[self class] new]
-                $right insert $number
             }
+            tailcall $right insert $number
         }
         return
     }
@@ -65,7 +44,7 @@ oo::class create BinarySearchTree {
     }
 
     method foreach {varName body {level 1}} {
-        if {[my hasLeft]} {
+        if {[info exists left]} {
             $left foreach $varName $body [expr {$level + 1}]
         }
 
@@ -73,8 +52,19 @@ oo::class create BinarySearchTree {
         set var [self]
         uplevel $level $body
 
-        if {[my hasRight]} {
+        if {[info exists right]} {
             $right foreach $varName $body [expr {$level + 1}]
         }
+    }
+
+    method toDict {} {
+        set result [list data $data left {} right {}]
+        if {[info exists left]} {
+            dict set result left [$left toDict]
+        }
+        if {[info exists right]} {
+            dict set result right [$right toDict]
+        }
+        return $result
     }
 }

--- a/lib/testMatchers.tcl
+++ b/lib/testMatchers.tcl
@@ -17,7 +17,19 @@ proc dictionaryMatch {expected actual} {
         if {![dict exists $actual $key]} {
             return false
         }
-        if {[dict get $actual $key] != $value} {
+        set actualValue [dict get $actual $key]
+
+        # if this value is a dict then recurse, 
+        # else just check for string equality
+        if {[string is list -strict $value] &&
+            [llength $value] > 1 && 
+            [llength $value] % 2 == 0
+        } {
+            set procname [lindex [info level 0] 0]
+            if {![$procname $value $actualValue]} {
+                return false
+            }
+        } elseif {$actualValue ne $value} {
             return false
         }
     }


### PR DESCRIPTION
Expected values in the tests should be more like the JSON values of the canonical data.

Also, makes the dictionaryMatch function recursive: allows for more whitespace.