### PR TITLE
alphametics: make the "big" test optional to speed up CI

### DIFF
--- a/exercises/alphametics/alphametics.test
+++ b/exercises/alphametics/alphametics.test
@@ -47,7 +47,8 @@ customMatch dictionary dictionaryMatch
 
 if {$::argv0 eq [info script]} {
 
-    #configure -verbose [concat [configure -verbose] msec]
+    # Uncomment to view the timing of each test
+    #configure -verbose [list {*}[configure -verbose] msec]
 
     set cases {
         alphametics-1 "puzzle with three letters"
@@ -77,9 +78,16 @@ if {$::argv0 eq [info script]} {
         alphametics-9 "puzzle with ten letters"
             "AND + A + STRONG + OFFENSE + AS + A + GOOD == DEFENSE"
             { A 5 D 3 E 4 F 7 G 8 N 0 O 2 R 1 S 6 T 9 }
-        alphametics-10 "puzzle with ten letters and 199 addends"
+    }
+
+    # Change this to "true" to enable the bonus test, and
+    # really exercise your code.
+    if {false} {
+        lappend cases {*}{
+            alphametics-10 "puzzle with ten letters and 199 addends"
             "THIS + A + FIRE + THEREFORE + FOR + ALL + HISTORIES + I + TELL + A + TALE + THAT + FALSIFIES + ITS + TITLE + TIS + A + LIE + THE + TALE + OF + THE + LAST + FIRE + HORSES + LATE + AFTER + THE + FIRST + FATHERS + FORESEE + THE + HORRORS + THE + LAST + FREE + TROLL + TERRIFIES + THE + HORSES + OF + FIRE + THE + TROLL + RESTS + AT + THE + HOLE + OF + LOSSES + IT + IS + THERE + THAT + SHE + STORES + ROLES + OF + LEATHERS + AFTER + SHE + SATISFIES + HER + HATE + OFF + THOSE + FEARS + A + TASTE + RISES + AS + SHE + HEARS + THE + LEAST + FAR + HORSE + THOSE + FAST + HORSES + THAT + FIRST + HEAR + THE + TROLL + FLEE + OFF + TO + THE + FOREST + THE + HORSES + THAT + ALERTS + RAISE + THE + STARES + OF + THE + OTHERS + AS + THE + TROLL + ASSAILS + AT + THE + TOTAL + SHIFT + HER + TEETH + TEAR + HOOF + OFF + TORSO + AS + THE + LAST + HORSE + FORFEITS + ITS + LIFE + THE + FIRST + FATHERS + HEAR + OF + THE + HORRORS + THEIR + FEARS + THAT + THE + FIRES + FOR + THEIR + FEASTS + ARREST + AS + THE + FIRST + FATHERS + RESETTLE + THE + LAST + OF + THE + FIRE + HORSES + THE + LAST + TROLL + HARASSES + THE + FOREST + HEART + FREE + AT + LAST + OF + THE + LAST + TROLL + ALL + OFFER + THEIR + FIRE + HEAT + TO + THE + ASSISTERS + FAR + OFF + THE + TROLL + FASTS + ITS + LIFE + SHORTER + AS + STARS + RISE + THE + HORSES + REST + SAFE + AFTER + ALL + SHARE + HOT + FISH + AS + THEIR + AFFILIATES + TAILOR + A + ROOFS + FOR + THEIR + SAFE == FORTRESSES"
             { A 1 E 0 F 5 H 8 I 7 L 2 O 6 R 3 S 4 T 9 }
+        }
     }
 
     foreach {name description puzzle result} $cases {


### PR DESCRIPTION
This implementation of alphametics isn't blazing fast. The last test case takes about 20 seconds to calculate.

Making this case optional will speed up CI for all commits to master.