### PR TITLE
[v3] Update Markdown files to latest spec

### DIFF
--- a/config/exercise-readme-insert.md
+++ b/config/exercise-readme-insert.md
@@ -1,0 +1,2 @@
+# exercise readme insert
+

--- a/docs/ABOUT.md
+++ b/docs/ABOUT.md
@@ -1,3 +1,5 @@
+# About
+
 Tcl, pronounced "tickle" and short for Tool Command Language, is a
 dynamic, open source programming language.
 

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -1,3 +1,5 @@
+# Installation
+
 ## Installing tclsh
 
 The only tool you need is the TCL interpreter, `tclsh`.

--- a/docs/LEARNING.md
+++ b/docs/LEARNING.md
@@ -1,3 +1,5 @@
+# Learning
+
 Tcl was designed with the goal of being very simple but powerful.
 
 For that reason, learning 

--- a/docs/RESOURCES.md
+++ b/docs/RESOURCES.md
@@ -1,3 +1,5 @@
+# Resources
+
  - The [#tcl](http://webchat.freenode.net/?channels=tcl) IRC channel on irc.freenode.net. This IRC channel is inter-linked with a number of other IRC channels.
  - The [Tcler's Wiki](https://wiki.tcl-lang.org/), a vast collection of resources gathered by Tcl programmers.
  - [Stack Overflow](http://stackoverflow.com/questions/tagged/tcl) can be used to search for your problem and see if it has been answered already. You can also ask and answer questions.

--- a/docs/TESTS.md
+++ b/docs/TESTS.md
@@ -1,4 +1,4 @@
-## Running the tests
+# Running the tests
 
 To run the tests for an exercise, run the `<exercise>.test` script in the
 exercise directory:

--- a/exercises/practice/accumulate/.docs/instructions.append.md
+++ b/exercises/practice/accumulate/.docs/instructions.append.md
@@ -1,3 +1,5 @@
+# Instructions append
+
 ### Hints
 
 You'll need to use the [uplevel](https://tcl.tk/man/tcl8.6/TclCmd/upvar.htm)

--- a/exercises/practice/accumulate/.docs/instructions.append.md
+++ b/exercises/practice/accumulate/.docs/instructions.append.md
@@ -1,6 +1,6 @@
 # Instructions append
 
-### Hints
+## Hints
 
 You'll need to use the [uplevel](https://tcl.tk/man/tcl8.6/TclCmd/upvar.htm)
 and [upvar](https://tcl.tk/man/tcl8.6/TclCmd/upvar.htm) commands for this

--- a/exercises/practice/accumulate/.docs/instructions.append.md
+++ b/exercises/practice/accumulate/.docs/instructions.append.md
@@ -1,6 +1,4 @@
-# Instructions append
-
-## Hints
+# Hints
 
 You'll need to use the [uplevel](https://tcl.tk/man/tcl8.6/TclCmd/upvar.htm)
 and [upvar](https://tcl.tk/man/tcl8.6/TclCmd/upvar.htm) commands for this

--- a/exercises/practice/bank-account/.docs/instructions.append.md
+++ b/exercises/practice/bank-account/.docs/instructions.append.md
@@ -1,4 +1,4 @@
-## Threads
+# Threads
 
 This exercises introduces threads to test how robust your bank account is 
 for concurrent operations. Some reading material for Tcl threads:

--- a/exercises/practice/dot-dsl/.docs/instructions.append.md
+++ b/exercises/practice/dot-dsl/.docs/instructions.append.md
@@ -1,3 +1,5 @@
+# Instructions append
+
 The DOT language has a [formal specification][DOT-spec]: the tests for this
 exercise do not expect the full specification to be implemented.
 

--- a/exercises/practice/dot-dsl/.docs/instructions.append.md
+++ b/exercises/practice/dot-dsl/.docs/instructions.append.md
@@ -1,10 +1,9 @@
-# Instructions append
+# DOT Language Spec
 
-The DOT language has a [formal specification][DOT-spec]: the tests for this
-exercise do not expect the full specification to be implemented.
+Although the DOT language has a [formal specification][DOT-spec], the tests for this exercise do not expect the full specification to be implemented.
 
-The Tcl wiki has some notes about DSLs:
-https://wiki.tcl-lang.org/page/domain-specific+language.
+The Tcl wiki has [some notes about domain-specific languages][DSL-wiki].
 
 [DOT-spec]: https://www.graphviz.org/doc/info/lang.html
+[DSL-wiki]: https://wiki.tcl-lang.org/page/domain-specific+language
 

--- a/exercises/practice/error-handling/.docs/instructions.append.md
+++ b/exercises/practice/error-handling/.docs/instructions.append.md
@@ -1,4 +1,4 @@
-## Resources
+# Resources
 
 The Tcl Wiki entry on [Errors management](https://wiki.tcl-lang.org/page/Errors+management)
 is useful for this exercise.

--- a/exercises/practice/list-ops/.docs/instructions.append.md
+++ b/exercises/practice/list-ops/.docs/instructions.append.md
@@ -1,4 +1,4 @@
-## The Tcl `apply` command
+# The Tcl `apply` command
 
 The test cases may look confusing. You are expected to implement this: 
 ```tcl

--- a/exercises/practice/matching-brackets/.docs/instructions.append.md
+++ b/exercises/practice/matching-brackets/.docs/instructions.append.md
@@ -1,4 +1,4 @@
-## Notes on brackets
+# Notes on brackets
 
 Tcl is a [very simple language](https://tcl.tk/man/tcl8.6/TclCmd/Tcl.htm),
 but the way they interpreter parses code has a couple of nasty edge cases.

--- a/exercises/practice/matching-brackets/.docs/instructions.append.md
+++ b/exercises/practice/matching-brackets/.docs/instructions.append.md
@@ -3,7 +3,7 @@
 Tcl is a [very simple language](https://tcl.tk/man/tcl8.6/TclCmd/Tcl.htm),
 but the way they interpreter parses code has a couple of nasty edge cases.
 
-### Curly braces
+## Curly braces
 
 Braces in Tcl are simply a way to quote a block of text -- that text may be
 interpreted as code or data. Within braces, nested braces may appear but
@@ -34,13 +34,13 @@ This can be problematic with the way Tcl parses comments, which is different
 from most languages.  There is more discussion on the [Tcl
 wiki](https://wiki.tcl-lang.org/page/Why+can+I+not+place+unmatched+braces+in+Tcl+comments).
 
-### Square brackets
+## Square brackets
 
 Similarly, since Tcl uses brackets for [Command
 substitution.](https://tcl.tk/man/tcl8.6/TclCmd/Tcl.htm#M11), even within
 double quoted strings, you have to be careful about escaping open brackets.
 
-### Parentheses
+## Parentheses
 
 With the exception of [associative array
 variables](https://tcl.tk/man/tcl8.6/TclCmd/Tcl.htm#M12), parentheses are

--- a/exercises/practice/parallel-letter-frequency/.docs/instructions.append.md
+++ b/exercises/practice/parallel-letter-frequency/.docs/instructions.append.md
@@ -1,4 +1,4 @@
-## Threads
+# Threads
 
 You'll implement parallelism with threads: subdivide the input into chunks
 that code running in a thread can examine asynchronously. 

--- a/exercises/practice/reverse-string/.meta/deprecated.md
+++ b/exercises/practice/reverse-string/.meta/deprecated.md
@@ -1,3 +1,5 @@
+# Deprecated
+
 This exercise is deprecated as being too easy: it will not help user's
 fluency in Tcl by reimplementing this basic builtin command
 ([string reverse](https://tcl.tk/man/tcl8.6/TclCmd/string.htm#M43)).

--- a/exercises/practice/zipper/.docs/instructions.append.md
+++ b/exercises/practice/zipper/.docs/instructions.append.md
@@ -1,3 +1,3 @@
-## Scope
+# Scope
 
 You'll find a Tree class already implemented for you. Your task is to write the Zipper class.


### PR DESCRIPTION
We've defined a [specification for Markdown files](https://github.com/exercism/docs/blob/main/contributing/standards/markdown.md) to be applied Exercism-wide. This standard includes, amongst others, the following two rules:

- All files must start start with a level-1 heading (`# Some heading text`)
- No heading may decend a level greater than one below the previous (e.g. `## may only be followed by ###, not ####`)

This PR applies the above two rules to the Markdown documents in this repo. 

## Tracking

https://github.com/exercism/v3-launch/issues/17
