### PR TITLE
The testing script called from the PR GHA workflow needs help

### DIFF
--- a/scripts/pr
+++ b/scripts/pr
@@ -16,9 +16,14 @@ status=0
 
 for file; do
     dir=$(dirname "$file")
+
+    # The example.tcl script lives in the exercises/practice/[exercise]/.meta
+    # directory.  We want to strip that off:
+    dir=${dir%/.meta}
+
     if [[ ! -v seen["$dir"] ]]; then
         seen["$dir"]=1
-        bin/test_one_exercise "$(basename "$dir")" || status=1
+        bin/test_one_exercise "$dir" || status=1
     fi
 done
 


### PR DESCRIPTION
Need to account for:

* the example.tcl file now lives in the .meta directory
* the pr script takes the relative path to the exercise folder, not just the slug name.