### PR TITLE
Populate "files" section in each exercise config.json

### DIFF
--- a/exercises/practice/accumulate/.meta/config.json
+++ b/exercises/practice/accumulate/.meta/config.json
@@ -2,9 +2,15 @@
   "blurb": "Implement the `accumulate` operation, which, given a collection and an operation to perform on each element of the collection, returns a new collection containing the result of applying that operation to each element of the input collection.",
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
-    "example": []
+    "solution": [
+      "accumulate.tcl"
+    ],
+    "test": [
+      "accumulate.test"
+    ],
+    "example": [
+      ".meta/example.tcl"
+    ]
   },
   "source": "Conversation with James Edward Gray II",
   "source_url": "https://twitter.com/jeg2"

--- a/exercises/practice/acronym/.meta/config.json
+++ b/exercises/practice/acronym/.meta/config.json
@@ -2,9 +2,15 @@
   "blurb": "Convert a long phrase to its acronym",
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
-    "example": []
+    "solution": [
+      "acronym.tcl"
+    ],
+    "test": [
+      "acronym.test"
+    ],
+    "example": [
+      ".meta/example.tcl"
+    ]
   },
   "source": "Julien Vanier",
   "source_url": "https://github.com/monkbroc"

--- a/exercises/practice/affine-cipher/.meta/config.json
+++ b/exercises/practice/affine-cipher/.meta/config.json
@@ -2,9 +2,15 @@
   "blurb": "Create an implementation of the Affine cipher, an ancient encryption algorithm from the Middle East.",
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
-    "example": []
+    "solution": [
+      "affine-cipher.tcl"
+    ],
+    "test": [
+      "affine-cipher.test"
+    ],
+    "example": [
+      ".meta/example.tcl"
+    ]
   },
   "source": "Wikipedia",
   "source_url": "http://en.wikipedia.org/wiki/Affine_cipher"

--- a/exercises/practice/all-your-base/.meta/config.json
+++ b/exercises/practice/all-your-base/.meta/config.json
@@ -2,8 +2,14 @@
   "blurb": "Convert a number, represented as a sequence of digits in one base, to any other base.",
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
-    "example": []
+    "solution": [
+      "all-your-base.tcl"
+    ],
+    "test": [
+      "all-your-base.test"
+    ],
+    "example": [
+      ".meta/example.tcl"
+    ]
   }
 }

--- a/exercises/practice/allergies/.meta/config.json
+++ b/exercises/practice/allergies/.meta/config.json
@@ -2,9 +2,15 @@
   "blurb": "Given a person's allergy score, determine whether or not they're allergic to a given item, and their full list of allergies.",
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
-    "example": []
+    "solution": [
+      "allergies.tcl"
+    ],
+    "test": [
+      "allergies.test"
+    ],
+    "example": [
+      ".meta/example.tcl"
+    ]
   },
   "source": "Jumpstart Lab Warm-up",
   "source_url": "http://jumpstartlab.com"

--- a/exercises/practice/alphametics/.meta/config.json
+++ b/exercises/practice/alphametics/.meta/config.json
@@ -2,8 +2,14 @@
   "blurb": "Write a function to solve alphametics puzzles.",
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
-    "example": []
+    "solution": [
+      "alphametics.tcl"
+    ],
+    "test": [
+      "alphametics.test"
+    ],
+    "example": [
+      ".meta/example.tcl"
+    ]
   }
 }

--- a/exercises/practice/anagram/.meta/config.json
+++ b/exercises/practice/anagram/.meta/config.json
@@ -2,9 +2,15 @@
   "blurb": "Given a word and a list of possible anagrams, select the correct sublist.",
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
-    "example": []
+    "solution": [
+      "anagram.tcl"
+    ],
+    "test": [
+      "anagram.test"
+    ],
+    "example": [
+      ".meta/example.tcl"
+    ]
   },
   "source": "Inspired by the Extreme Startup game",
   "source_url": "https://github.com/rchatley/extreme_startup"

--- a/exercises/practice/armstrong-numbers/.meta/config.json
+++ b/exercises/practice/armstrong-numbers/.meta/config.json
@@ -2,9 +2,15 @@
   "blurb": "Determine if a number is an Armstrong number",
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
-    "example": []
+    "solution": [
+      "armstrong-numbers.tcl"
+    ],
+    "test": [
+      "armstrong-numbers.test"
+    ],
+    "example": [
+      ".meta/example.tcl"
+    ]
   },
   "source": "Wikipedia",
   "source_url": "https://en.wikipedia.org/wiki/Narcissistic_number"

--- a/exercises/practice/atbash-cipher/.meta/config.json
+++ b/exercises/practice/atbash-cipher/.meta/config.json
@@ -2,9 +2,15 @@
   "blurb": "Create an implementation of the atbash cipher, an ancient encryption system created in the Middle East.",
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
-    "example": []
+    "solution": [
+      "atbash-cipher.tcl"
+    ],
+    "test": [
+      "atbash-cipher.test"
+    ],
+    "example": [
+      ".meta/example.tcl"
+    ]
   },
   "source": "Wikipedia",
   "source_url": "http://en.wikipedia.org/wiki/Atbash"

--- a/exercises/practice/bank-account/.meta/config.json
+++ b/exercises/practice/bank-account/.meta/config.json
@@ -2,8 +2,14 @@
   "blurb": "Simulate a bank account supporting opening/closing, withdraws, and deposits of money. Watch out for concurrent transactions!",
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
-    "example": []
+    "solution": [
+      "bank-account.tcl"
+    ],
+    "test": [
+      "bank-account.test"
+    ],
+    "example": [
+      ".meta/example.tcl"
+    ]
   }
 }

--- a/exercises/practice/beer-song/.meta/config.json
+++ b/exercises/practice/beer-song/.meta/config.json
@@ -2,9 +2,15 @@
   "blurb": "Produce the lyrics to that beloved classic, that field-trip favorite: 99 Bottles of Beer on the Wall.",
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
-    "example": []
+    "solution": [
+      "beer-song.tcl"
+    ],
+    "test": [
+      "beer-song.test"
+    ],
+    "example": [
+      ".meta/example.tcl"
+    ]
   },
   "source": "Learn to Program by Chris Pine",
   "source_url": "http://pine.fm/LearnToProgram/?Chapter=06"

--- a/exercises/practice/binary-search-tree/.meta/config.json
+++ b/exercises/practice/binary-search-tree/.meta/config.json
@@ -2,9 +2,15 @@
   "blurb": "Insert and search for numbers in a binary tree.",
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
-    "example": []
+    "solution": [
+      "binary-search-tree.tcl"
+    ],
+    "test": [
+      "binary-search-tree.test"
+    ],
+    "example": [
+      ".meta/example.tcl"
+    ]
   },
   "source": "Josh Cheek",
   "source_url": "https://twitter.com/josh_cheek"

--- a/exercises/practice/binary-search/.meta/config.json
+++ b/exercises/practice/binary-search/.meta/config.json
@@ -2,9 +2,15 @@
   "blurb": "Implement a binary search algorithm.",
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
-    "example": []
+    "solution": [
+      "binary-search.tcl"
+    ],
+    "test": [
+      "binary-search.test"
+    ],
+    "example": [
+      ".meta/example.tcl"
+    ]
   },
   "source": "Wikipedia",
   "source_url": "http://en.wikipedia.org/wiki/Binary_search_algorithm"

--- a/exercises/practice/bob/.meta/config.json
+++ b/exercises/practice/bob/.meta/config.json
@@ -2,9 +2,15 @@
   "blurb": "Bob is a lackadaisical teenager. In conversation, his responses are very limited.",
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
-    "example": []
+    "solution": [
+      "bob.tcl"
+    ],
+    "test": [
+      "bob.test"
+    ],
+    "example": [
+      ".meta/example.tcl"
+    ]
   },
   "source": "Inspired by the 'Deaf Grandma' exercise in Chris Pine's Learn to Program tutorial.",
   "source_url": "http://pine.fm/LearnToProgram/?Chapter=06"

--- a/exercises/practice/book-store/.meta/config.json
+++ b/exercises/practice/book-store/.meta/config.json
@@ -2,9 +2,15 @@
   "blurb": "To try and encourage more sales of different books from a popular 5 book series, a bookshop has decided to offer discounts of multiple-book purchases.",
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
-    "example": []
+    "solution": [
+      "book-store.tcl"
+    ],
+    "test": [
+      "book-store.test"
+    ],
+    "example": [
+      ".meta/example.tcl"
+    ]
   },
   "source": "Inspired by the harry potter kata from Cyber-Dojo.",
   "source_url": "http://cyber-dojo.org"

--- a/exercises/practice/bowling/.meta/config.json
+++ b/exercises/practice/bowling/.meta/config.json
@@ -2,9 +2,15 @@
   "blurb": "Score a bowling game",
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
-    "example": []
+    "solution": [
+      "bowling.tcl"
+    ],
+    "test": [
+      "bowling.test"
+    ],
+    "example": [
+      ".meta/example.tcl"
+    ]
   },
   "source": "The Bowling Game Kata at but UncleBob",
   "source_url": "http://butunclebob.com/ArticleS.UncleBob.TheBowlingGameKata"

--- a/exercises/practice/change/.meta/config.json
+++ b/exercises/practice/change/.meta/config.json
@@ -2,9 +2,15 @@
   "blurb": "Correctly determine change to be given using the least number of coins",
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
-    "example": []
+    "solution": [
+      "change.tcl"
+    ],
+    "test": [
+      "change.test"
+    ],
+    "example": [
+      ".meta/example.tcl"
+    ]
   },
   "source": "Software Craftsmanship - Coin Change Kata",
   "source_url": "https://web.archive.org/web/20130115115225/http://craftsmanship.sv.cmu.edu:80/exercises/coin-change-kata"

--- a/exercises/practice/circular-buffer/.meta/config.json
+++ b/exercises/practice/circular-buffer/.meta/config.json
@@ -2,9 +2,15 @@
   "blurb": "A data structure that uses a single, fixed-size buffer as if it were connected end-to-end.",
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
-    "example": []
+    "solution": [
+      "circular-buffer.tcl"
+    ],
+    "test": [
+      "circular-buffer.test"
+    ],
+    "example": [
+      ".meta/example.tcl"
+    ]
   },
   "source": "Wikipedia",
   "source_url": "http://en.wikipedia.org/wiki/Circular_buffer"

--- a/exercises/practice/clock/.meta/config.json
+++ b/exercises/practice/clock/.meta/config.json
@@ -2,9 +2,15 @@
   "blurb": "Implement a clock that handles times without dates.",
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
-    "example": []
+    "solution": [
+      "clock.tcl"
+    ],
+    "test": [
+      "clock.test"
+    ],
+    "example": [
+      ".meta/example.tcl"
+    ]
   },
   "source": "Pairing session with Erin Drummond",
   "source_url": "https://twitter.com/ebdrummond"

--- a/exercises/practice/collatz-conjecture/.meta/config.json
+++ b/exercises/practice/collatz-conjecture/.meta/config.json
@@ -2,9 +2,15 @@
   "blurb": "Calculate the number of steps to reach 1 using the Collatz conjecture",
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
-    "example": []
+    "solution": [
+      "collatz-conjecture.tcl"
+    ],
+    "test": [
+      "collatz-conjecture.test"
+    ],
+    "example": [
+      ".meta/example.tcl"
+    ]
   },
   "source": "An unsolved problem in mathematics named after mathematician Lothar Collatz",
   "source_url": "https://en.wikipedia.org/wiki/3x_%2B_1_problem"

--- a/exercises/practice/complex-numbers/.meta/config.json
+++ b/exercises/practice/complex-numbers/.meta/config.json
@@ -2,9 +2,15 @@
   "blurb": "Implement complex numbers.",
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
-    "example": []
+    "solution": [
+      "complex-numbers.tcl"
+    ],
+    "test": [
+      "complex-numbers.test"
+    ],
+    "example": [
+      ".meta/example.tcl"
+    ]
   },
   "source": "Wikipedia",
   "source_url": "https://en.wikipedia.org/wiki/Complex_number"

--- a/exercises/practice/connect/.meta/config.json
+++ b/exercises/practice/connect/.meta/config.json
@@ -2,8 +2,14 @@
   "blurb": "Compute the result for a game of Hex / Polygon",
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
-    "example": []
+    "solution": [
+      "connect.tcl"
+    ],
+    "test": [
+      "connect.test"
+    ],
+    "example": [
+      ".meta/example.tcl"
+    ]
   }
 }

--- a/exercises/practice/crypto-square/.meta/config.json
+++ b/exercises/practice/crypto-square/.meta/config.json
@@ -2,9 +2,15 @@
   "blurb": "Implement the classic method for composing secret messages called a square code.",
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
-    "example": []
+    "solution": [
+      "crypto-square.tcl"
+    ],
+    "test": [
+      "crypto-square.test"
+    ],
+    "example": [
+      ".meta/example.tcl"
+    ]
   },
   "source": "J Dalbey's Programming Practice problems",
   "source_url": "http://users.csc.calpoly.edu/~jdalbey/103/Projects/ProgrammingPractice.html"

--- a/exercises/practice/custom-set/.meta/config.json
+++ b/exercises/practice/custom-set/.meta/config.json
@@ -2,8 +2,14 @@
   "blurb": "Create a custom set type.",
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
-    "example": []
+    "solution": [
+      "custom-set.tcl"
+    ],
+    "test": [
+      "custom-set.test"
+    ],
+    "example": [
+      ".meta/example.tcl"
+    ]
   }
 }

--- a/exercises/practice/darts/.meta/config.json
+++ b/exercises/practice/darts/.meta/config.json
@@ -2,9 +2,15 @@
   "blurb": "Write a function that returns the earned points in a single toss of a Darts game",
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
-    "example": []
+    "solution": [
+      "darts.tcl"
+    ],
+    "test": [
+      "darts.test"
+    ],
+    "example": [
+      ".meta/example.tcl"
+    ]
   },
   "source": "Inspired by an exercise created by a professor Della Paolera in Argentina"
 }

--- a/exercises/practice/diamond/.meta/config.json
+++ b/exercises/practice/diamond/.meta/config.json
@@ -2,9 +2,15 @@
   "blurb": "Given a letter, print a diamond starting with 'A' with the supplied letter at the widest point.",
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
-    "example": []
+    "solution": [
+      "diamond.tcl"
+    ],
+    "test": [
+      "diamond.test"
+    ],
+    "example": [
+      ".meta/example.tcl"
+    ]
   },
   "source": "Seb Rose",
   "source_url": "http://claysnow.co.uk/recycling-tests-in-tdd/"

--- a/exercises/practice/difference-of-squares/.meta/config.json
+++ b/exercises/practice/difference-of-squares/.meta/config.json
@@ -2,9 +2,15 @@
   "blurb": "Find the difference between the square of the sum and the sum of the squares of the first N natural numbers.",
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
-    "example": []
+    "solution": [
+      "difference-of-squares.tcl"
+    ],
+    "test": [
+      "difference-of-squares.test"
+    ],
+    "example": [
+      ".meta/example.tcl"
+    ]
   },
   "source": "Problem 6 at Project Euler",
   "source_url": "http://projecteuler.net/problem=6"

--- a/exercises/practice/diffie-hellman/.meta/config.json
+++ b/exercises/practice/diffie-hellman/.meta/config.json
@@ -2,9 +2,15 @@
   "blurb": "Diffie-Hellman key exchange.",
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
-    "example": []
+    "solution": [
+      "diffie-hellman.tcl"
+    ],
+    "test": [
+      "diffie-hellman.test"
+    ],
+    "example": [
+      ".meta/example.tcl"
+    ]
   },
   "source": "Wikipedia, 1024 bit key from www.cryptopp.com/wiki.",
   "source_url": "http://en.wikipedia.org/wiki/Diffie%E2%80%93Hellman_key_exchange"

--- a/exercises/practice/dnd-character/.meta/config.json
+++ b/exercises/practice/dnd-character/.meta/config.json
@@ -2,9 +2,15 @@
   "blurb": "Randomly generate Dungeons & Dragons characters",
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
-    "example": []
+    "solution": [
+      "dnd-character.tcl"
+    ],
+    "test": [
+      "dnd-character.test"
+    ],
+    "example": [
+      ".meta/example.tcl"
+    ]
   },
   "source": "Simon Shine, Erik Schierboom",
   "source_url": "https://github.com/exercism/problem-specifications/issues/616#issuecomment-437358945"

--- a/exercises/practice/dominoes/.meta/config.json
+++ b/exercises/practice/dominoes/.meta/config.json
@@ -2,8 +2,14 @@
   "blurb": "Make a chain of dominoes.",
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
-    "example": []
+    "solution": [
+      "dominoes.tcl"
+    ],
+    "test": [
+      "dominoes.test"
+    ],
+    "example": [
+      ".meta/example.tcl"
+    ]
   }
 }

--- a/exercises/practice/dot-dsl/.meta/config.json
+++ b/exercises/practice/dot-dsl/.meta/config.json
@@ -2,9 +2,15 @@
   "blurb": "Write a Domain Specific Language similar to the Graphviz dot language",
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
-    "example": []
+    "solution": [
+      "dot-dsl.tcl"
+    ],
+    "test": [
+      "dot-dsl.test"
+    ],
+    "example": [
+      ".meta/example.tcl"
+    ]
   },
   "source": "Wikipedia",
   "source_url": "https://en.wikipedia.org/wiki/DOT_(graph_description_language)"

--- a/exercises/practice/error-handling/.meta/config.json
+++ b/exercises/practice/error-handling/.meta/config.json
@@ -2,8 +2,14 @@
   "blurb": "Implement various kinds of error handling and resource management",
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
-    "example": []
+    "solution": [
+      "error-handling.tcl"
+    ],
+    "test": [
+      "error-handling.test"
+    ],
+    "example": [
+      ".meta/example.tcl"
+    ]
   }
 }

--- a/exercises/practice/etl/.meta/config.json
+++ b/exercises/practice/etl/.meta/config.json
@@ -2,9 +2,15 @@
   "blurb": "We are going to do the `Transform` step of an Extract-Transform-Load.",
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
-    "example": []
+    "solution": [
+      "etl.tcl"
+    ],
+    "test": [
+      "etl.test"
+    ],
+    "example": [
+      ".meta/example.tcl"
+    ]
   },
   "source": "The Jumpstart Lab team",
   "source_url": "http://jumpstartlab.com"

--- a/exercises/practice/flatten-array/.meta/config.json
+++ b/exercises/practice/flatten-array/.meta/config.json
@@ -2,9 +2,15 @@
   "blurb": "Take a nested list and return a single list with all values except nil/null",
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
-    "example": []
+    "solution": [
+      "flatten-array.tcl"
+    ],
+    "test": [
+      "flatten-array.test"
+    ],
+    "example": [
+      ".meta/example.tcl"
+    ]
   },
   "source": "Interview Question",
   "source_url": "https://reference.wolfram.com/language/ref/Flatten.html"

--- a/exercises/practice/food-chain/.meta/config.json
+++ b/exercises/practice/food-chain/.meta/config.json
@@ -2,9 +2,15 @@
   "blurb": "Generate the lyrics of the song 'I Know an Old Lady Who Swallowed a Fly'",
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
-    "example": []
+    "solution": [
+      "food-chain.tcl"
+    ],
+    "test": [
+      "food-chain.test"
+    ],
+    "example": [
+      ".meta/example.tcl"
+    ]
   },
   "source": "Wikipedia",
   "source_url": "http://en.wikipedia.org/wiki/There_Was_an_Old_Lady_Who_Swallowed_a_Fly"

--- a/exercises/practice/forth/.meta/config.json
+++ b/exercises/practice/forth/.meta/config.json
@@ -2,8 +2,14 @@
   "blurb": "Implement an evaluator for a very simple subset of Forth",
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
-    "example": []
+    "solution": [
+      "forth.tcl"
+    ],
+    "test": [
+      "forth.test"
+    ],
+    "example": [
+      ".meta/example.tcl"
+    ]
   }
 }

--- a/exercises/practice/gigasecond/.meta/config.json
+++ b/exercises/practice/gigasecond/.meta/config.json
@@ -2,9 +2,15 @@
   "blurb": "Given a moment, determine the moment that would be after a gigasecond has passed.",
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
-    "example": []
+    "solution": [
+      "gigasecond.tcl"
+    ],
+    "test": [
+      "gigasecond.test"
+    ],
+    "example": [
+      ".meta/example.tcl"
+    ]
   },
   "source": "Chapter 9 in Chris Pine's online Learn to Program tutorial.",
   "source_url": "http://pine.fm/LearnToProgram/?Chapter=09"

--- a/exercises/practice/go-counting/.meta/config.json
+++ b/exercises/practice/go-counting/.meta/config.json
@@ -2,8 +2,14 @@
   "blurb": "Count the scored points on a Go board.",
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
-    "example": []
+    "solution": [
+      "go-counting.tcl"
+    ],
+    "test": [
+      "go-counting.test"
+    ],
+    "example": [
+      ".meta/example.tcl"
+    ]
   }
 }

--- a/exercises/practice/grade-school/.meta/config.json
+++ b/exercises/practice/grade-school/.meta/config.json
@@ -2,9 +2,15 @@
   "blurb": "Given students' names along with the grade that they are in, create a roster for the school",
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
-    "example": []
+    "solution": [
+      "grade-school.tcl"
+    ],
+    "test": [
+      "grade-school.test"
+    ],
+    "example": [
+      ".meta/example.tcl"
+    ]
   },
   "source": "A pairing session with Phil Battos at gSchool",
   "source_url": "http://gschool.it"

--- a/exercises/practice/grains/.meta/config.json
+++ b/exercises/practice/grains/.meta/config.json
@@ -2,9 +2,15 @@
   "blurb": "Calculate the number of grains of wheat on a chessboard given that the number on each square doubles.",
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
-    "example": []
+    "solution": [
+      "grains.tcl"
+    ],
+    "test": [
+      "grains.test"
+    ],
+    "example": [
+      ".meta/example.tcl"
+    ]
   },
   "source": "JavaRanch Cattle Drive, exercise 6",
   "source_url": "http://www.javaranch.com/grains.jsp"

--- a/exercises/practice/grep/.meta/config.json
+++ b/exercises/practice/grep/.meta/config.json
@@ -2,9 +2,15 @@
   "blurb": "Search a file for lines matching a regular expression pattern. Return the line number and contents of each matching line.",
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
-    "example": []
+    "solution": [
+      "grep.tcl"
+    ],
+    "test": [
+      "grep.test"
+    ],
+    "example": [
+      ".meta/example.tcl"
+    ]
   },
   "source": "Conversation with Nate Foster.",
   "source_url": "http://www.cs.cornell.edu/Courses/cs3110/2014sp/hw/0/ps0.pdf"

--- a/exercises/practice/hamming/.meta/config.json
+++ b/exercises/practice/hamming/.meta/config.json
@@ -2,9 +2,15 @@
   "blurb": "Calculate the Hamming difference between two DNA strands.",
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
-    "example": []
+    "solution": [
+      "hamming.tcl"
+    ],
+    "test": [
+      "hamming.test"
+    ],
+    "example": [
+      ".meta/example.tcl"
+    ]
   },
   "source": "The Calculating Point Mutations problem at Rosalind",
   "source_url": "http://rosalind.info/problems/hamm/"

--- a/exercises/practice/hello-world/.meta/config.json
+++ b/exercises/practice/hello-world/.meta/config.json
@@ -2,9 +2,15 @@
   "blurb": "The classical introductory exercise. Just say \"Hello, World!\"",
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
-    "example": []
+    "solution": [
+      "hello-world.tcl"
+    ],
+    "test": [
+      "hello-world.test"
+    ],
+    "example": [
+      ".meta/example.tcl"
+    ]
   },
   "source": "This is an exercise to introduce users to using Exercism",
   "source_url": "http://en.wikipedia.org/wiki/%22Hello,_world!%22_program"

--- a/exercises/practice/high-scores/.meta/config.json
+++ b/exercises/practice/high-scores/.meta/config.json
@@ -2,9 +2,15 @@
   "blurb": "Manage a player's High Score list",
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
-    "example": []
+    "solution": [
+      "high-scores.tcl"
+    ],
+    "test": [
+      "high-scores.test"
+    ],
+    "example": [
+      ".meta/example.tcl"
+    ]
   },
   "source": "Tribute to the eighties' arcade game Frogger"
 }

--- a/exercises/practice/house/.meta/config.json
+++ b/exercises/practice/house/.meta/config.json
@@ -2,9 +2,15 @@
   "blurb": "Output the nursery rhyme 'This is the House that Jack Built'.",
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
-    "example": []
+    "solution": [
+      "house.tcl"
+    ],
+    "test": [
+      "house.test"
+    ],
+    "example": [
+      ".meta/example.tcl"
+    ]
   },
   "source": "British nursery rhyme",
   "source_url": "http://en.wikipedia.org/wiki/This_Is_The_House_That_Jack_Built"

--- a/exercises/practice/isbn-verifier/.meta/config.json
+++ b/exercises/practice/isbn-verifier/.meta/config.json
@@ -2,9 +2,15 @@
   "blurb": "Check if a given string is a valid ISBN-10 number.",
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
-    "example": []
+    "solution": [
+      "isbn-verifier.tcl"
+    ],
+    "test": [
+      "isbn-verifier.test"
+    ],
+    "example": [
+      ".meta/example.tcl"
+    ]
   },
   "source": "Converting a string into a number and some basic processing utilizing a relatable real world example.",
   "source_url": "https://en.wikipedia.org/wiki/International_Standard_Book_Number#ISBN-10_check_digit_calculation"

--- a/exercises/practice/isogram/.meta/config.json
+++ b/exercises/practice/isogram/.meta/config.json
@@ -2,9 +2,15 @@
   "blurb": "Determine if a word or phrase is an isogram.",
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
-    "example": []
+    "solution": [
+      "isogram.tcl"
+    ],
+    "test": [
+      "isogram.test"
+    ],
+    "example": [
+      ".meta/example.tcl"
+    ]
   },
   "source": "Wikipedia",
   "source_url": "https://en.wikipedia.org/wiki/Isogram"

--- a/exercises/practice/kindergarten-garden/.meta/config.json
+++ b/exercises/practice/kindergarten-garden/.meta/config.json
@@ -2,9 +2,15 @@
   "blurb": "Given a diagram, determine which plants each child in the kindergarten class is responsible for.",
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
-    "example": []
+    "solution": [
+      "kindergarten-garden.tcl"
+    ],
+    "test": [
+      "kindergarten-garden.test"
+    ],
+    "example": [
+      ".meta/example.tcl"
+    ]
   },
   "source": "Random musings during airplane trip.",
   "source_url": "http://jumpstartlab.com"

--- a/exercises/practice/knapsack/.meta/config.json
+++ b/exercises/practice/knapsack/.meta/config.json
@@ -2,9 +2,15 @@
   "blurb": "Given a knapsack that can only carry a certain weight, determine which items to put in the knapsack in order to maximize their combined value.",
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
-    "example": []
+    "solution": [
+      "knapsack.tcl"
+    ],
+    "test": [
+      "knapsack.test"
+    ],
+    "example": [
+      ".meta/example.tcl"
+    ]
   },
   "source": "Wikipedia",
   "source_url": "https://en.wikipedia.org/wiki/Knapsack_problem"

--- a/exercises/practice/largest-series-product/.meta/config.json
+++ b/exercises/practice/largest-series-product/.meta/config.json
@@ -2,9 +2,15 @@
   "blurb": "Given a string of digits, calculate the largest product for a contiguous substring of digits of length n.",
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
-    "example": []
+    "solution": [
+      "largest-series-product.tcl"
+    ],
+    "test": [
+      "largest-series-product.test"
+    ],
+    "example": [
+      ".meta/example.tcl"
+    ]
   },
   "source": "A variation on Problem 8 at Project Euler",
   "source_url": "http://projecteuler.net/problem=8"

--- a/exercises/practice/leap/.meta/config.json
+++ b/exercises/practice/leap/.meta/config.json
@@ -2,9 +2,15 @@
   "blurb": "Given a year, report if it is a leap year.",
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
-    "example": []
+    "solution": [
+      "leap.tcl"
+    ],
+    "test": [
+      "leap.test"
+    ],
+    "example": [
+      ".meta/example.tcl"
+    ]
   },
   "source": "JavaRanch Cattle Drive, exercise 3",
   "source_url": "http://www.javaranch.com/leap.jsp"

--- a/exercises/practice/linked-list/.meta/config.json
+++ b/exercises/practice/linked-list/.meta/config.json
@@ -2,9 +2,15 @@
   "blurb": "Implement a doubly linked list",
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
-    "example": []
+    "solution": [
+      "linked-list.tcl"
+    ],
+    "test": [
+      "linked-list.test"
+    ],
+    "example": [
+      ".meta/example.tcl"
+    ]
   },
   "source": "Classic computer science topic"
 }

--- a/exercises/practice/list-ops/.meta/config.json
+++ b/exercises/practice/list-ops/.meta/config.json
@@ -2,8 +2,14 @@
   "blurb": "Implement basic list operations",
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
-    "example": []
+    "solution": [
+      "list-ops.tcl"
+    ],
+    "test": [
+      "list-ops.test"
+    ],
+    "example": [
+      ".meta/example.tcl"
+    ]
   }
 }

--- a/exercises/practice/luhn/.meta/config.json
+++ b/exercises/practice/luhn/.meta/config.json
@@ -2,9 +2,15 @@
   "blurb": "Given a number determine whether or not it is valid per the Luhn formula.",
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
-    "example": []
+    "solution": [
+      "luhn.tcl"
+    ],
+    "test": [
+      "luhn.test"
+    ],
+    "example": [
+      ".meta/example.tcl"
+    ]
   },
   "source": "The Luhn Algorithm on Wikipedia",
   "source_url": "http://en.wikipedia.org/wiki/Luhn_algorithm"

--- a/exercises/practice/markdown/.meta/config.json
+++ b/exercises/practice/markdown/.meta/config.json
@@ -2,8 +2,14 @@
   "blurb": "Refactor a Markdown parser",
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
-    "example": []
+    "solution": [
+      "markdown.tcl"
+    ],
+    "test": [
+      "markdown.test"
+    ],
+    "example": [
+      ".meta/example.tcl"
+    ]
   }
 }

--- a/exercises/practice/matching-brackets/.meta/config.json
+++ b/exercises/practice/matching-brackets/.meta/config.json
@@ -2,9 +2,15 @@
   "blurb": "Make sure the brackets and braces all match.",
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
-    "example": []
+    "solution": [
+      "matching-brackets.tcl"
+    ],
+    "test": [
+      "matching-brackets.test"
+    ],
+    "example": [
+      ".meta/example.tcl"
+    ]
   },
   "source": "Ginna Baker"
 }

--- a/exercises/practice/matrix/.meta/config.json
+++ b/exercises/practice/matrix/.meta/config.json
@@ -2,9 +2,15 @@
   "blurb": "Given a string representing a matrix of numbers, return the rows and columns of that matrix.",
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
-    "example": []
+    "solution": [
+      "matrix.tcl"
+    ],
+    "test": [
+      "matrix.test"
+    ],
+    "example": [
+      ".meta/example.tcl"
+    ]
   },
   "source": "Warmup to the `saddle-points` warmup.",
   "source_url": "http://jumpstartlab.com"

--- a/exercises/practice/meetup/.meta/config.json
+++ b/exercises/practice/meetup/.meta/config.json
@@ -2,9 +2,15 @@
   "blurb": "Calculate the date of meetups.",
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
-    "example": []
+    "solution": [
+      "meetup.tcl"
+    ],
+    "test": [
+      "meetup.test"
+    ],
+    "example": [
+      ".meta/example.tcl"
+    ]
   },
   "source": "Jeremy Hinegardner mentioned a Boulder meetup that happens on the Wednesteenth of every month",
   "source_url": "https://twitter.com/copiousfreetime"

--- a/exercises/practice/minesweeper/.meta/config.json
+++ b/exercises/practice/minesweeper/.meta/config.json
@@ -2,8 +2,14 @@
   "blurb": "Add the numbers to a minesweeper board",
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
-    "example": []
+    "solution": [
+      "minesweeper.tcl"
+    ],
+    "test": [
+      "minesweeper.test"
+    ],
+    "example": [
+      ".meta/example.tcl"
+    ]
   }
 }

--- a/exercises/practice/nth-prime/.meta/config.json
+++ b/exercises/practice/nth-prime/.meta/config.json
@@ -2,9 +2,15 @@
   "blurb": "Given a number n, determine what the nth prime is.",
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
-    "example": []
+    "solution": [
+      "nth-prime.tcl"
+    ],
+    "test": [
+      "nth-prime.test"
+    ],
+    "example": [
+      ".meta/example.tcl"
+    ]
   },
   "source": "A variation on Problem 7 at Project Euler",
   "source_url": "http://projecteuler.net/problem=7"

--- a/exercises/practice/nucleotide-count/.meta/config.json
+++ b/exercises/practice/nucleotide-count/.meta/config.json
@@ -2,9 +2,15 @@
   "blurb": "Given a DNA string, compute how many times each nucleotide occurs in the string.",
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
-    "example": []
+    "solution": [
+      "nucleotide-count.tcl"
+    ],
+    "test": [
+      "nucleotide-count.test"
+    ],
+    "example": [
+      ".meta/example.tcl"
+    ]
   },
   "source": "The Calculating DNA Nucleotides_problem at Rosalind",
   "source_url": "http://rosalind.info/problems/dna/"

--- a/exercises/practice/ocr-numbers/.meta/config.json
+++ b/exercises/practice/ocr-numbers/.meta/config.json
@@ -2,9 +2,15 @@
   "blurb": "Given a 3 x 4 grid of pipes, underscores, and spaces, determine which number is represented, or whether it is garbled.",
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
-    "example": []
+    "solution": [
+      "ocr-numbers.tcl"
+    ],
+    "test": [
+      "ocr-numbers.test"
+    ],
+    "example": [
+      ".meta/example.tcl"
+    ]
   },
   "source": "Inspired by the Bank OCR kata",
   "source_url": "http://codingdojo.org/cgi-bin/wiki.pl?KataBankOCR"

--- a/exercises/practice/palindrome-products/.meta/config.json
+++ b/exercises/practice/palindrome-products/.meta/config.json
@@ -2,9 +2,15 @@
   "blurb": "Detect palindrome products in a given range.",
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
-    "example": []
+    "solution": [
+      "palindrome-products.tcl"
+    ],
+    "test": [
+      "palindrome-products.test"
+    ],
+    "example": [
+      ".meta/example.tcl"
+    ]
   },
   "source": "Problem 4 at Project Euler",
   "source_url": "http://projecteuler.net/problem=4"

--- a/exercises/practice/pangram/.meta/config.json
+++ b/exercises/practice/pangram/.meta/config.json
@@ -2,9 +2,15 @@
   "blurb": "Determine if a sentence is a pangram.",
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
-    "example": []
+    "solution": [
+      "pangram.tcl"
+    ],
+    "test": [
+      "pangram.test"
+    ],
+    "example": [
+      ".meta/example.tcl"
+    ]
   },
   "source": "Wikipedia",
   "source_url": "https://en.wikipedia.org/wiki/Pangram"

--- a/exercises/practice/parallel-letter-frequency/.meta/config.json
+++ b/exercises/practice/parallel-letter-frequency/.meta/config.json
@@ -2,8 +2,14 @@
   "blurb": "Count the frequency of letters in texts using parallel computation.",
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
-    "example": []
+    "solution": [
+      "parallel-letter-frequency.tcl"
+    ],
+    "test": [
+      "parallel-letter-frequency.test"
+    ],
+    "example": [
+      ".meta/example.tcl"
+    ]
   }
 }

--- a/exercises/practice/pascals-triangle/.meta/config.json
+++ b/exercises/practice/pascals-triangle/.meta/config.json
@@ -2,9 +2,15 @@
   "blurb": "Compute Pascal's triangle up to a given number of rows.",
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
-    "example": []
+    "solution": [
+      "pascals-triangle.tcl"
+    ],
+    "test": [
+      "pascals-triangle.test"
+    ],
+    "example": [
+      ".meta/example.tcl"
+    ]
   },
   "source": "Pascal's Triangle at Wolfram Math World",
   "source_url": "http://mathworld.wolfram.com/PascalsTriangle.html"

--- a/exercises/practice/perfect-numbers/.meta/config.json
+++ b/exercises/practice/perfect-numbers/.meta/config.json
@@ -2,9 +2,15 @@
   "blurb": "Determine if a number is perfect, abundant, or deficient based on Nicomachus' (60 - 120 CE) classification scheme for positive integers.",
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
-    "example": []
+    "solution": [
+      "perfect-numbers.tcl"
+    ],
+    "test": [
+      "perfect-numbers.test"
+    ],
+    "example": [
+      ".meta/example.tcl"
+    ]
   },
   "source": "Taken from Chapter 2 of Functional Thinking by Neal Ford.",
   "source_url": "http://shop.oreilly.com/product/0636920029687.do"

--- a/exercises/practice/phone-number/.meta/config.json
+++ b/exercises/practice/phone-number/.meta/config.json
@@ -2,9 +2,15 @@
   "blurb": "Clean up user-entered phone numbers so that they can be sent SMS messages.",
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
-    "example": []
+    "solution": [
+      "phone-number.tcl"
+    ],
+    "test": [
+      "phone-number.test"
+    ],
+    "example": [
+      ".meta/example.tcl"
+    ]
   },
   "source": "Event Manager by JumpstartLab",
   "source_url": "http://tutorials.jumpstartlab.com/projects/eventmanager.html"

--- a/exercises/practice/pig-latin/.meta/config.json
+++ b/exercises/practice/pig-latin/.meta/config.json
@@ -2,9 +2,15 @@
   "blurb": "Implement a program that translates from English to Pig Latin",
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
-    "example": []
+    "solution": [
+      "pig-latin.tcl"
+    ],
+    "test": [
+      "pig-latin.test"
+    ],
+    "example": [
+      ".meta/example.tcl"
+    ]
   },
   "source": "The Pig Latin exercise at Test First Teaching by Ultrasaurus",
   "source_url": "https://github.com/ultrasaurus/test-first-teaching/blob/master/learn_ruby/pig_latin/"

--- a/exercises/practice/poker/.meta/config.json
+++ b/exercises/practice/poker/.meta/config.json
@@ -2,9 +2,15 @@
   "blurb": "Pick the best hand(s) from a list of poker hands.",
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
-    "example": []
+    "solution": [
+      "poker.tcl"
+    ],
+    "test": [
+      "poker.test"
+    ],
+    "example": [
+      ".meta/example.tcl"
+    ]
   },
   "source": "Inspired by the training course from Udacity.",
   "source_url": "https://www.udacity.com/course/viewer#!/c-cs212/"

--- a/exercises/practice/pov/.meta/config.json
+++ b/exercises/practice/pov/.meta/config.json
@@ -2,9 +2,15 @@
   "blurb": "Reparent a graph on a selected node",
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
-    "example": []
+    "solution": [
+      "pov.tcl"
+    ],
+    "test": [
+      "pov.test"
+    ],
+    "example": [
+      ".meta/example.tcl"
+    ]
   },
   "source": "Adaptation of exercise from 4clojure",
   "source_url": "https://www.4clojure.com/"

--- a/exercises/practice/prime-factors/.meta/config.json
+++ b/exercises/practice/prime-factors/.meta/config.json
@@ -2,9 +2,15 @@
   "blurb": "Compute the prime factors of a given natural number.",
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
-    "example": []
+    "solution": [
+      "prime-factors.tcl"
+    ],
+    "test": [
+      "prime-factors.test"
+    ],
+    "example": [
+      ".meta/example.tcl"
+    ]
   },
   "source": "The Prime Factors Kata by Uncle Bob",
   "source_url": "http://butunclebob.com/ArticleS.UncleBob.ThePrimeFactorsKata"

--- a/exercises/practice/protein-translation/.meta/config.json
+++ b/exercises/practice/protein-translation/.meta/config.json
@@ -2,9 +2,15 @@
   "blurb": "Translate RNA sequences into proteins.",
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
-    "example": []
+    "solution": [
+      "protein-translation.tcl"
+    ],
+    "test": [
+      "protein-translation.test"
+    ],
+    "example": [
+      ".meta/example.tcl"
+    ]
   },
   "source": "Tyler Long"
 }

--- a/exercises/practice/proverb/.meta/config.json
+++ b/exercises/practice/proverb/.meta/config.json
@@ -2,9 +2,15 @@
   "blurb": "For want of a horseshoe nail, a kingdom was lost, or so the saying goes. Output the full text of this proverbial rhyme.",
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
-    "example": []
+    "solution": [
+      "proverb.tcl"
+    ],
+    "test": [
+      "proverb.test"
+    ],
+    "example": [
+      ".meta/example.tcl"
+    ]
   },
   "source": "Wikipedia",
   "source_url": "http://en.wikipedia.org/wiki/For_Want_of_a_Nail"

--- a/exercises/practice/pythagorean-triplet/.meta/config.json
+++ b/exercises/practice/pythagorean-triplet/.meta/config.json
@@ -2,9 +2,15 @@
   "blurb": "There exists exactly one Pythagorean triplet for which a + b + c = 1000. Find the product a * b * c.",
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
-    "example": []
+    "solution": [
+      "pythagorean-triplet.tcl"
+    ],
+    "test": [
+      "pythagorean-triplet.test"
+    ],
+    "example": [
+      ".meta/example.tcl"
+    ]
   },
   "source": "Problem 9 at Project Euler",
   "source_url": "http://projecteuler.net/problem=9"

--- a/exercises/practice/queen-attack/.meta/config.json
+++ b/exercises/practice/queen-attack/.meta/config.json
@@ -2,9 +2,15 @@
   "blurb": "Given the position of two queens on a chess board, indicate whether or not they are positioned so that they can attack each other.",
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
-    "example": []
+    "solution": [
+      "queen-attack.tcl"
+    ],
+    "test": [
+      "queen-attack.test"
+    ],
+    "example": [
+      ".meta/example.tcl"
+    ]
   },
   "source": "J Dalbey's Programming Practice problems",
   "source_url": "http://users.csc.calpoly.edu/~jdalbey/103/Projects/ProgrammingPractice.html"

--- a/exercises/practice/rail-fence-cipher/.meta/config.json
+++ b/exercises/practice/rail-fence-cipher/.meta/config.json
@@ -2,9 +2,15 @@
   "blurb": "Implement encoding and decoding for the rail fence cipher.",
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
-    "example": []
+    "solution": [
+      "rail-fence-cipher.tcl"
+    ],
+    "test": [
+      "rail-fence-cipher.test"
+    ],
+    "example": [
+      ".meta/example.tcl"
+    ]
   },
   "source": "Wikipedia",
   "source_url": "https://en.wikipedia.org/wiki/Transposition_cipher#Rail_Fence_cipher"

--- a/exercises/practice/raindrops/.meta/config.json
+++ b/exercises/practice/raindrops/.meta/config.json
@@ -2,9 +2,15 @@
   "blurb": "Convert a number to a string, the content of which depends on the number's factors.",
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
-    "example": []
+    "solution": [
+      "raindrops.tcl"
+    ],
+    "test": [
+      "raindrops.test"
+    ],
+    "example": [
+      ".meta/example.tcl"
+    ]
   },
   "source": "A variation on FizzBuzz, a famous technical interview question that is intended to weed out potential candidates. That question is itself derived from Fizz Buzz, a popular children's game for teaching division.",
   "source_url": "https://en.wikipedia.org/wiki/Fizz_buzz"

--- a/exercises/practice/rational-numbers/.meta/config.json
+++ b/exercises/practice/rational-numbers/.meta/config.json
@@ -2,9 +2,15 @@
   "blurb": "Implement rational numbers.",
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
-    "example": []
+    "solution": [
+      "rational-numbers.tcl"
+    ],
+    "test": [
+      "rational-numbers.test"
+    ],
+    "example": [
+      ".meta/example.tcl"
+    ]
   },
   "source": "Wikipedia",
   "source_url": "https://en.wikipedia.org/wiki/Rational_number"

--- a/exercises/practice/react/.meta/config.json
+++ b/exercises/practice/react/.meta/config.json
@@ -2,8 +2,14 @@
   "blurb": "Implement a basic reactive system.",
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
-    "example": []
+    "solution": [
+      "react.tcl"
+    ],
+    "test": [
+      "react.test"
+    ],
+    "example": [
+      ".meta/example.tcl"
+    ]
   }
 }

--- a/exercises/practice/rectangles/.meta/config.json
+++ b/exercises/practice/rectangles/.meta/config.json
@@ -2,8 +2,14 @@
   "blurb": "Count the rectangles in an ASCII diagram.",
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
-    "example": []
+    "solution": [
+      "rectangles.tcl"
+    ],
+    "test": [
+      "rectangles.test"
+    ],
+    "example": [
+      ".meta/example.tcl"
+    ]
   }
 }

--- a/exercises/practice/resistor-color-duo/.meta/config.json
+++ b/exercises/practice/resistor-color-duo/.meta/config.json
@@ -2,9 +2,15 @@
   "blurb": "Convert color codes, as used on resistors, to a numeric value.",
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
-    "example": []
+    "solution": [
+      "resistor-color-duo.tcl"
+    ],
+    "test": [
+      "resistor-color-duo.test"
+    ],
+    "example": [
+      ".meta/example.tcl"
+    ]
   },
   "source": "Maud de Vries, Erik Schierboom",
   "source_url": "https://github.com/exercism/problem-specifications/issues/1464"

--- a/exercises/practice/resistor-color-trio/.meta/config.json
+++ b/exercises/practice/resistor-color-trio/.meta/config.json
@@ -2,9 +2,15 @@
   "blurb": "Convert color codes, as used on resistors, to a human-readable label.",
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
-    "example": []
+    "solution": [
+      "resistor-color-trio.tcl"
+    ],
+    "test": [
+      "resistor-color-trio.test"
+    ],
+    "example": [
+      ".meta/example.tcl"
+    ]
   },
   "source": "Maud de Vries, Erik Schierboom",
   "source_url": "https://github.com/exercism/problem-specifications/issues/1549"

--- a/exercises/practice/resistor-color/.meta/config.json
+++ b/exercises/practice/resistor-color/.meta/config.json
@@ -2,9 +2,15 @@
   "blurb": "Convert a resistor band's color to its numeric representation",
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
-    "example": []
+    "solution": [
+      "resistor-color.tcl"
+    ],
+    "test": [
+      "resistor-color.test"
+    ],
+    "example": [
+      ".meta/example.tcl"
+    ]
   },
   "source": "Maud de Vries, Erik Schierboom",
   "source_url": "https://github.com/exercism/problem-specifications/issues/1458"

--- a/exercises/practice/rest-api/.meta/config.json
+++ b/exercises/practice/rest-api/.meta/config.json
@@ -2,8 +2,14 @@
   "blurb": "Implement a RESTful API for tracking IOUs.",
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
-    "example": []
+    "solution": [
+      "rest-api.tcl"
+    ],
+    "test": [
+      "rest-api.test"
+    ],
+    "example": [
+      ".meta/example.tcl"
+    ]
   }
 }

--- a/exercises/practice/reverse-string/.meta/config.json
+++ b/exercises/practice/reverse-string/.meta/config.json
@@ -2,9 +2,15 @@
   "blurb": "Reverse a string",
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
-    "example": []
+    "solution": [
+      "reverse-string.tcl"
+    ],
+    "test": [
+      "reverse-string.test"
+    ],
+    "example": [
+      ".meta/example.tcl"
+    ]
   },
   "source": "Introductory challenge to reverse an input string",
   "source_url": "https://medium.freecodecamp.org/how-to-reverse-a-string-in-javascript-in-3-different-ways-75e4763c68cb"

--- a/exercises/practice/rna-transcription/.meta/config.json
+++ b/exercises/practice/rna-transcription/.meta/config.json
@@ -2,9 +2,15 @@
   "blurb": "Given a DNA strand, return its RNA Complement Transcription.",
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
-    "example": []
+    "solution": [
+      "rna-transcription.tcl"
+    ],
+    "test": [
+      "rna-transcription.test"
+    ],
+    "example": [
+      ".meta/example.tcl"
+    ]
   },
   "source": "Hyperphysics",
   "source_url": "http://hyperphysics.phy-astr.gsu.edu/hbase/Organic/transcription.html"

--- a/exercises/practice/robot-name/.meta/config.json
+++ b/exercises/practice/robot-name/.meta/config.json
@@ -2,9 +2,15 @@
   "blurb": "Manage robot factory settings.",
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
-    "example": []
+    "solution": [
+      "robot-name.tcl"
+    ],
+    "test": [
+      "robot-name.test"
+    ],
+    "example": [
+      ".meta/example.tcl"
+    ]
   },
   "source": "A debugging session with Paul Blackwell at gSchool."
 }

--- a/exercises/practice/robot-simulator/.meta/config.json
+++ b/exercises/practice/robot-simulator/.meta/config.json
@@ -2,9 +2,15 @@
   "blurb": "Write a robot simulator.",
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
-    "example": []
+    "solution": [
+      "robot-simulator.tcl"
+    ],
+    "test": [
+      "robot-simulator.test"
+    ],
+    "example": [
+      ".meta/example.tcl"
+    ]
   },
   "source": "Inspired by an interview question at a famous company.",
   "source_url": ""

--- a/exercises/practice/roman-numerals/.meta/config.json
+++ b/exercises/practice/roman-numerals/.meta/config.json
@@ -2,9 +2,15 @@
   "blurb": "Write a function to convert from normal numbers to Roman Numerals.",
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
-    "example": []
+    "solution": [
+      "roman-numerals.tcl"
+    ],
+    "test": [
+      "roman-numerals.test"
+    ],
+    "example": [
+      ".meta/example.tcl"
+    ]
   },
   "source": "The Roman Numeral Kata",
   "source_url": "http://codingdojo.org/cgi-bin/index.pl?KataRomanNumerals"

--- a/exercises/practice/rotational-cipher/.meta/config.json
+++ b/exercises/practice/rotational-cipher/.meta/config.json
@@ -2,9 +2,15 @@
   "blurb": "Create an implementation of the rotational cipher, also sometimes called the Caesar cipher.",
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
-    "example": []
+    "solution": [
+      "rotational-cipher.tcl"
+    ],
+    "test": [
+      "rotational-cipher.test"
+    ],
+    "example": [
+      ".meta/example.tcl"
+    ]
   },
   "source": "Wikipedia",
   "source_url": "https://en.wikipedia.org/wiki/Caesar_cipher"

--- a/exercises/practice/run-length-encoding/.meta/config.json
+++ b/exercises/practice/run-length-encoding/.meta/config.json
@@ -2,9 +2,15 @@
   "blurb": "Implement run-length encoding and decoding.",
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
-    "example": []
+    "solution": [
+      "run-length-encoding.tcl"
+    ],
+    "test": [
+      "run-length-encoding.test"
+    ],
+    "example": [
+      ".meta/example.tcl"
+    ]
   },
   "source": "Wikipedia",
   "source_url": "https://en.wikipedia.org/wiki/Run-length_encoding"

--- a/exercises/practice/saddle-points/.meta/config.json
+++ b/exercises/practice/saddle-points/.meta/config.json
@@ -2,9 +2,15 @@
   "blurb": "Detect saddle points in a matrix.",
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
-    "example": []
+    "solution": [
+      "saddle-points.tcl"
+    ],
+    "test": [
+      "saddle-points.test"
+    ],
+    "example": [
+      ".meta/example.tcl"
+    ]
   },
   "source": "J Dalbey's Programming Practice problems",
   "source_url": "http://users.csc.calpoly.edu/~jdalbey/103/Projects/ProgrammingPractice.html"

--- a/exercises/practice/satellite/.meta/config.json
+++ b/exercises/practice/satellite/.meta/config.json
@@ -2,8 +2,14 @@
   "blurb": "Rebuild binary trees from pre-order and in-order traversals.",
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
-    "example": []
+    "solution": [
+      "satellite.tcl"
+    ],
+    "test": [
+      "satellite.test"
+    ],
+    "example": [
+      ".meta/example.tcl"
+    ]
   }
 }

--- a/exercises/practice/say/.meta/config.json
+++ b/exercises/practice/say/.meta/config.json
@@ -2,9 +2,15 @@
   "blurb": "Given a number from 0 to 999,999,999,999, spell out that number in English.",
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
-    "example": []
+    "solution": [
+      "say.tcl"
+    ],
+    "test": [
+      "say.test"
+    ],
+    "example": [
+      ".meta/example.tcl"
+    ]
   },
   "source": "A variation on JavaRanch CattleDrive, exercise 4a",
   "source_url": "http://www.javaranch.com/say.jsp"

--- a/exercises/practice/scale-generator/.meta/config.json
+++ b/exercises/practice/scale-generator/.meta/config.json
@@ -2,8 +2,14 @@
   "blurb": "Generate musical scales, given a starting note and a set of intervals. ",
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
-    "example": []
+    "solution": [
+      "scale-generator.tcl"
+    ],
+    "test": [
+      "scale-generator.test"
+    ],
+    "example": [
+      ".meta/example.tcl"
+    ]
   }
 }

--- a/exercises/practice/scrabble-score/.meta/config.json
+++ b/exercises/practice/scrabble-score/.meta/config.json
@@ -2,9 +2,15 @@
   "blurb": "Given a word, compute the Scrabble score for that word.",
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
-    "example": []
+    "solution": [
+      "scrabble-score.tcl"
+    ],
+    "test": [
+      "scrabble-score.test"
+    ],
+    "example": [
+      ".meta/example.tcl"
+    ]
   },
   "source": "Inspired by the Extreme Startup game",
   "source_url": "https://github.com/rchatley/extreme_startup"

--- a/exercises/practice/secret-handshake/.meta/config.json
+++ b/exercises/practice/secret-handshake/.meta/config.json
@@ -2,9 +2,15 @@
   "blurb": "Given a decimal number, convert it to the appropriate sequence of events for a secret handshake.",
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
-    "example": []
+    "solution": [
+      "secret-handshake.tcl"
+    ],
+    "test": [
+      "secret-handshake.test"
+    ],
+    "example": [
+      ".meta/example.tcl"
+    ]
   },
   "source": "Bert, in Mary Poppins",
   "source_url": "http://www.imdb.com/title/tt0058331/quotes/qt0437047"

--- a/exercises/practice/series/.meta/config.json
+++ b/exercises/practice/series/.meta/config.json
@@ -2,9 +2,15 @@
   "blurb": "Given a string of digits, output all the contiguous substrings of length `n` in that string.",
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
-    "example": []
+    "solution": [
+      "series.tcl"
+    ],
+    "test": [
+      "series.test"
+    ],
+    "example": [
+      ".meta/example.tcl"
+    ]
   },
   "source": "A subset of the Problem 8 at Project Euler",
   "source_url": "http://projecteuler.net/problem=8"

--- a/exercises/practice/sieve/.meta/config.json
+++ b/exercises/practice/sieve/.meta/config.json
@@ -2,9 +2,15 @@
   "blurb": "Use the Sieve of Eratosthenes to find all the primes from 2 up to a given number.",
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
-    "example": []
+    "solution": [
+      "sieve.tcl"
+    ],
+    "test": [
+      "sieve.test"
+    ],
+    "example": [
+      ".meta/example.tcl"
+    ]
   },
   "source": "Sieve of Eratosthenes at Wikipedia",
   "source_url": "http://en.wikipedia.org/wiki/Sieve_of_Eratosthenes"

--- a/exercises/practice/simple-cipher/.meta/config.json
+++ b/exercises/practice/simple-cipher/.meta/config.json
@@ -2,9 +2,15 @@
   "blurb": "Implement a simple shift cipher like Caesar and a more secure substitution cipher",
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
-    "example": []
+    "solution": [
+      "simple-cipher.tcl"
+    ],
+    "test": [
+      "simple-cipher.test"
+    ],
+    "example": [
+      ".meta/example.tcl"
+    ]
   },
   "source": "Substitution Cipher at Wikipedia",
   "source_url": "http://en.wikipedia.org/wiki/Substitution_cipher"

--- a/exercises/practice/simple-linked-list/.meta/config.json
+++ b/exercises/practice/simple-linked-list/.meta/config.json
@@ -2,9 +2,15 @@
   "blurb": "Write a simple linked list implementation that uses Elements and a List",
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
-    "example": []
+    "solution": [
+      "simple-linked-list.tcl"
+    ],
+    "test": [
+      "simple-linked-list.test"
+    ],
+    "example": [
+      ".meta/example.tcl"
+    ]
   },
   "source": "Inspired by 'Data Structures and Algorithms with Object-Oriented Design Patterns in Ruby', singly linked-lists.",
   "source_url": "https://web.archive.org/web/20160731005714/http://brpreiss.com/books/opus8/html/page96.html"

--- a/exercises/practice/space-age/.meta/config.json
+++ b/exercises/practice/space-age/.meta/config.json
@@ -2,9 +2,15 @@
   "blurb": "Given an age in seconds, calculate how old someone is in terms of a given planet's solar years.",
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
-    "example": []
+    "solution": [
+      "space-age.tcl"
+    ],
+    "test": [
+      "space-age.test"
+    ],
+    "example": [
+      ".meta/example.tcl"
+    ]
   },
   "source": "Partially inspired by Chapter 1 in Chris Pine's online Learn to Program tutorial.",
   "source_url": "http://pine.fm/LearnToProgram/?Chapter=01"

--- a/exercises/practice/spiral-matrix/.meta/config.json
+++ b/exercises/practice/spiral-matrix/.meta/config.json
@@ -2,9 +2,15 @@
   "blurb": " Given the size, return a square matrix of numbers in spiral order.",
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
-    "example": []
+    "solution": [
+      "spiral-matrix.tcl"
+    ],
+    "test": [
+      "spiral-matrix.test"
+    ],
+    "example": [
+      ".meta/example.tcl"
+    ]
   },
   "source": "Reddit r/dailyprogrammer challenge #320 [Easy] Spiral Ascension.",
   "source_url": "https://www.reddit.com/r/dailyprogrammer/comments/6i60lr/20170619_challenge_320_easy_spiral_ascension/"

--- a/exercises/practice/square-root/.meta/config.json
+++ b/exercises/practice/square-root/.meta/config.json
@@ -2,9 +2,15 @@
   "blurb": "Given a natural radicand, return its square root.",
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
-    "example": []
+    "solution": [
+      "square-root.tcl"
+    ],
+    "test": [
+      "square-root.test"
+    ],
+    "example": [
+      ".meta/example.tcl"
+    ]
   },
   "source": "wolf99",
   "source_url": "https://github.com/exercism/problem-specifications/pull/1582"

--- a/exercises/practice/strain/.meta/config.json
+++ b/exercises/practice/strain/.meta/config.json
@@ -2,9 +2,15 @@
   "blurb": "Implement the `keep` and `discard` operation on collections. Given a collection and a predicate on the collection's elements, `keep` returns a new collection containing those elements where the predicate is true, while `discard` returns a new collection containing those elements where the predicate is false.",
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
-    "example": []
+    "solution": [
+      "strain.tcl"
+    ],
+    "test": [
+      "strain.test"
+    ],
+    "example": [
+      ".meta/example.tcl"
+    ]
   },
   "source": "Conversation with James Edward Gray II",
   "source_url": "https://twitter.com/jeg2"

--- a/exercises/practice/sublist/.meta/config.json
+++ b/exercises/practice/sublist/.meta/config.json
@@ -2,8 +2,14 @@
   "blurb": "Write a function to determine if a list is a sublist of another list.",
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
-    "example": []
+    "solution": [
+      "sublist.tcl"
+    ],
+    "test": [
+      "sublist.test"
+    ],
+    "example": [
+      ".meta/example.tcl"
+    ]
   }
 }

--- a/exercises/practice/sum-of-multiples/.meta/config.json
+++ b/exercises/practice/sum-of-multiples/.meta/config.json
@@ -2,9 +2,15 @@
   "blurb": "Given a number, find the sum of all the multiples of particular numbers up to but not including that number.",
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
-    "example": []
+    "solution": [
+      "sum-of-multiples.tcl"
+    ],
+    "test": [
+      "sum-of-multiples.test"
+    ],
+    "example": [
+      ".meta/example.tcl"
+    ]
   },
   "source": "A variation on Problem 1 at Project Euler",
   "source_url": "http://projecteuler.net/problem=1"

--- a/exercises/practice/tournament/.meta/config.json
+++ b/exercises/practice/tournament/.meta/config.json
@@ -2,8 +2,14 @@
   "blurb": "Tally the results of a small football competition.",
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
-    "example": []
+    "solution": [
+      "tournament.tcl"
+    ],
+    "test": [
+      "tournament.test"
+    ],
+    "example": [
+      ".meta/example.tcl"
+    ]
   }
 }

--- a/exercises/practice/transpose/.meta/config.json
+++ b/exercises/practice/transpose/.meta/config.json
@@ -2,9 +2,15 @@
   "blurb": "Take input text and output it transposed.",
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
-    "example": []
+    "solution": [
+      "transpose.tcl"
+    ],
+    "test": [
+      "transpose.test"
+    ],
+    "example": [
+      ".meta/example.tcl"
+    ]
   },
   "source": "Reddit r/dailyprogrammer challenge #270 [Easy].",
   "source_url": "https://www.reddit.com/r/dailyprogrammer/comments/4msu2x/challenge_270_easy_transpose_the_input_text"

--- a/exercises/practice/triangle/.meta/config.json
+++ b/exercises/practice/triangle/.meta/config.json
@@ -2,9 +2,15 @@
   "blurb": "Determine if a triangle is equilateral, isosceles, or scalene.",
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
-    "example": []
+    "solution": [
+      "triangle.tcl"
+    ],
+    "test": [
+      "triangle.test"
+    ],
+    "example": [
+      ".meta/example.tcl"
+    ]
   },
   "source": "The Ruby Koans triangle project, parts 1 & 2",
   "source_url": "http://rubykoans.com"

--- a/exercises/practice/twelve-days/.meta/config.json
+++ b/exercises/practice/twelve-days/.meta/config.json
@@ -2,9 +2,15 @@
   "blurb": "Output the lyrics to 'The Twelve Days of Christmas'",
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
-    "example": []
+    "solution": [
+      "twelve-days.tcl"
+    ],
+    "test": [
+      "twelve-days.test"
+    ],
+    "example": [
+      ".meta/example.tcl"
+    ]
   },
   "source": "Wikipedia",
   "source_url": "http://en.wikipedia.org/wiki/The_Twelve_Days_of_Christmas_(song)"

--- a/exercises/practice/two-bucket/.meta/config.json
+++ b/exercises/practice/two-bucket/.meta/config.json
@@ -2,9 +2,15 @@
   "blurb": "Given two buckets of different size, demonstrate how to measure an exact number of liters.",
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
-    "example": []
+    "solution": [
+      "two-bucket.tcl"
+    ],
+    "test": [
+      "two-bucket.test"
+    ],
+    "example": [
+      ".meta/example.tcl"
+    ]
   },
   "source": "Water Pouring Problem",
   "source_url": "http://demonstrations.wolfram.com/WaterPouringProblem/"

--- a/exercises/practice/two-fer/.meta/config.json
+++ b/exercises/practice/two-fer/.meta/config.json
@@ -2,9 +2,15 @@
   "blurb": "Create a sentence of the form \"One for X, one for me.\"",
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
-    "example": []
+    "solution": [
+      "two-fer.tcl"
+    ],
+    "test": [
+      "two-fer.test"
+    ],
+    "example": [
+      ".meta/example.tcl"
+    ]
   },
   "source_url": "https://github.com/exercism/problem-specifications/issues/757"
 }

--- a/exercises/practice/variable-length-quantity/.meta/config.json
+++ b/exercises/practice/variable-length-quantity/.meta/config.json
@@ -2,9 +2,15 @@
   "blurb": "Implement variable length quantity encoding and decoding.",
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
-    "example": []
+    "solution": [
+      "variable-length-quantity.tcl"
+    ],
+    "test": [
+      "variable-length-quantity.test"
+    ],
+    "example": [
+      ".meta/example.tcl"
+    ]
   },
   "source": "A poor Splice developer having to implement MIDI encoding/decoding.",
   "source_url": "https://splice.com"

--- a/exercises/practice/word-count/.meta/config.json
+++ b/exercises/practice/word-count/.meta/config.json
@@ -2,9 +2,15 @@
   "blurb": "Given a phrase, count the occurrences of each word in that phrase.",
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
-    "example": []
+    "solution": [
+      "word-count.tcl"
+    ],
+    "test": [
+      "word-count.test"
+    ],
+    "example": [
+      ".meta/example.tcl"
+    ]
   },
   "source": "This is a classic toy problem, but we were reminded of it by seeing it in the Go Tour."
 }

--- a/exercises/practice/word-search/.meta/config.json
+++ b/exercises/practice/word-search/.meta/config.json
@@ -2,8 +2,14 @@
   "blurb": "Create a program to solve a word search puzzle.",
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
-    "example": []
+    "solution": [
+      "word-search.tcl"
+    ],
+    "test": [
+      "word-search.test"
+    ],
+    "example": [
+      ".meta/example.tcl"
+    ]
   }
 }

--- a/exercises/practice/wordy/.meta/config.json
+++ b/exercises/practice/wordy/.meta/config.json
@@ -2,9 +2,15 @@
   "blurb": "Parse and evaluate simple math word problems returning the answer as an integer.",
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
-    "example": []
+    "solution": [
+      "wordy.tcl"
+    ],
+    "test": [
+      "wordy.test"
+    ],
+    "example": [
+      ".meta/example.tcl"
+    ]
   },
   "source": "Inspired by one of the generated questions in the Extreme Startup game.",
   "source_url": "https://github.com/rchatley/extreme_startup"

--- a/exercises/practice/yacht/.meta/config.json
+++ b/exercises/practice/yacht/.meta/config.json
@@ -2,9 +2,15 @@
   "blurb": "Score a single throw of dice in the game Yacht",
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
-    "example": []
+    "solution": [
+      "yacht.tcl"
+    ],
+    "test": [
+      "yacht.test"
+    ],
+    "example": [
+      ".meta/example.tcl"
+    ]
   },
   "source": "James Kilfiger, using wikipedia",
   "source_url": "https://en.wikipedia.org/wiki/Yacht_(dice_game)"

--- a/exercises/practice/zipper/.meta/config.json
+++ b/exercises/practice/zipper/.meta/config.json
@@ -2,8 +2,14 @@
   "blurb": "Creating a zipper for a binary tree.",
   "authors": [],
   "files": {
-    "solution": [],
-    "test": [],
-    "example": []
+    "solution": [
+      "zipper.tcl"
+    ],
+    "test": [
+      "zipper.test"
+    ],
+    "example": [
+      ".meta/example.tcl"
+    ]
   }
 }


### PR DESCRIPTION
This track only contains practice exercises.

script (fish):
```
cd exercises/practice
for d in *
    # track uses kebab-case for exercise files
    jq --arg s "$d.tcl" --arg t "$d.test" '
        .files = {
            "solution": [$s],
            "test": [$t],
            "example": [".meta/example.tcl"]
        }
    ' $d/.meta/config.json | sponge $d/.meta/config.json
end
```
