### PR TITLE
🤖 Add docs configuration

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -1,0 +1,32 @@
+{
+  "docs": [
+    {
+      "uuid": "ae2e539b-5c2b-4341-a962-c1afe6576296",
+      "slug": "installation",
+      "path": "docs/INSTALLATION.md",
+      "title": "Installing Tcl locally",
+      "blurb": "Learn how to install Tcl locally to solve Exercism's exercises on your own machine"
+    },
+    {
+      "uuid": "c3122d14-dd2a-4ec4-b247-c98c609a53f3",
+      "slug": "learning",
+      "path": "docs/LEARNING.md",
+      "title": "How to learn Tcl",
+      "blurb": "An overview of how to get started from scratch with Tcl"
+    },
+    {
+      "uuid": "88e44e57-19c7-4c6e-ad54-04d1bbef8034",
+      "slug": "tests",
+      "path": "docs/TESTS.md",
+      "title": "Testing on the Tcl track",
+      "blurb": "Learn how to test your Tcl exercises on Exercism"
+    },
+    {
+      "uuid": "5ad057d0-e7e4-492a-a31d-d5e9c48f91a0",
+      "slug": "resources",
+      "path": "docs/RESOURCES.md",
+      "title": "Useful Tcl resources",
+      "blurb": "A collection of useful resources to help you master Tcl"
+    }
+  ]
+}


### PR DESCRIPTION
To allow the v3 website to display the track's documentation, we're introducing a `docs/config.json` file, which contains information needed for rendering.

This commit adds the `docs/config.json` file. We will merge this PR shortly. For now, **please don't edit its contents**. We will follow up with a PR for CI, and with an issue linking you to the spec for this file once it's written up. Once that's all done, you will then be free to edit this config as normal 🙂

## Tracking

https://github.com/exercism/v3-launch/issues/25
