### PR TITLE
Un-deprecate the accumulate exercise

### DIFF
--- a/config.json
+++ b/config.json
@@ -741,8 +741,7 @@
           "callbacks",
           "lists",
           "loops"
-        ],
-        "status": "deprecated"
+        ]
       },
       {
         "slug": "two-bucket",

--- a/exercises/practice/accumulate/.docs/instructions.append.md
+++ b/exercises/practice/accumulate/.docs/instructions.append.md
@@ -1,0 +1,6 @@
+# Hints
+
+You'll need to use the [uplevel](https://tcl.tk/man/tcl8.6/TclCmd/upvar.htm)
+and [upvar](https://tcl.tk/man/tcl8.6/TclCmd/upvar.htm) commands for this
+exercise.
+

--- a/exercises/practice/accumulate/.docs/instructions.md
+++ b/exercises/practice/accumulate/.docs/instructions.md
@@ -1,0 +1,26 @@
+# Instructions
+
+Implement the `accumulate` operation, which, given a collection and an
+operation to perform on each element of the collection, returns a new
+collection containing the result of applying that operation to each element of
+the input collection.
+
+Given the collection of numbers:
+
+- 1, 2, 3, 4, 5
+
+And the operation:
+
+- square a number (`x => x * x`)
+
+Your code should be able to produce the collection of squares:
+
+- 1, 4, 9, 16, 25
+
+Check out the test suite to see the expected function signature.
+
+## Restrictions
+
+Keep your hands off that collect/map/fmap/whatchamacallit functionality
+provided by your standard library!
+Solve this one yourself using other basic tools instead.

--- a/exercises/practice/accumulate/.meta/config.json
+++ b/exercises/practice/accumulate/.meta/config.json
@@ -1,0 +1,22 @@
+{
+  "blurb": "Implement the `accumulate` operation, which, given a collection and an operation to perform on each element of the collection, returns a new collection containing the result of applying that operation to each element of the input collection.",
+  "authors": [
+    "glennj"
+  ],
+  "contributors": [
+    "sshine"
+  ],
+  "files": {
+    "solution": [
+      "accumulate.tcl"
+    ],
+    "test": [
+      "accumulate.test"
+    ],
+    "example": [
+      ".meta/example.tcl"
+    ]
+  },
+  "source": "Conversation with James Edward Gray II",
+  "source_url": "https://twitter.com/jeg2"
+}

--- a/exercises/practice/accumulate/.meta/example.tcl
+++ b/exercises/practice/accumulate/.meta/example.tcl
@@ -1,0 +1,8 @@
+proc accumulate {varname list body} {
+    upvar 1 $varname element
+    set result [list]
+    foreach element $list {
+        lappend result [uplevel 1 $body]
+    }
+    return $result
+}

--- a/exercises/practice/accumulate/.meta/tests.toml
+++ b/exercises/practice/accumulate/.meta/tests.toml
@@ -1,0 +1,18 @@
+# This is an auto-generated file. Regular comments will be removed when this
+# file is regenerated. Regenerating will not touch any manually added keys,
+# so comments can be added in a "comment" key.
+
+[64d97c14-36dd-44a8-9621-2cecebd6ed23]
+description = "accumulate empty"
+
+[00008ed2-4651-4929-8c08-8b4dbd70872e]
+description = "accumulate squares"
+
+[551016da-4396-4cae-b0ec-4c3a1a264125]
+description = "accumulate upcases"
+
+[cdf95597-b6ec-4eac-a838-3480d13d0d05]
+description = "accumulate reversed strings"
+
+[bee8e9b6-b16f-4cd2-be3b-ccf7457e50bb]
+description = "accumulate recursively"

--- a/exercises/practice/accumulate/README.md
+++ b/exercises/practice/accumulate/README.md
@@ -1,0 +1,5 @@
+# Accumulate
+
+This exercise has been deprecated.
+
+It is a trivial reimplementation of the builtin `lmap` command.

--- a/exercises/practice/accumulate/accumulate.tcl
+++ b/exercises/practice/accumulate/accumulate.tcl
@@ -1,0 +1,3 @@
+proc accumulate {varname values body} {
+    throw {NOT_IMPLEMENTED} "Implement this procedure."
+}

--- a/exercises/practice/accumulate/accumulate.test
+++ b/exercises/practice/accumulate/accumulate.test
@@ -1,0 +1,91 @@
+#!/usr/bin/env tclsh
+package require tcltest
+namespace import ::tcltest::*
+source "accumulate.tcl"
+
+proc fail_fast {} {
+    return [expr {
+        ![info exists ::env(RUN_ALL)]
+        || [string is boolean -strict $::env(RUN_ALL)]
+        && !$::env(RUN_ALL)
+    }]
+}
+
+proc failed {} {
+    return [expr {$::tcltest::numTests(Failed) > 0}]
+}
+
+if {[fail_fast]} {
+    proc test args {
+        if {[failed]} {::tcltest::configure -skip *}
+        uplevel [list ::tcltest::test {*}$args]
+    }
+}
+
+proc cleanupTests {} {
+    set failed [failed]
+    uplevel 1 ::tcltest::cleanupTests
+    if {$failed} {exit 1}
+}
+
+if {$::argv0 eq [info script]} {
+
+    test accumulate-1 "empty list" -body {
+        accumulate n {} { expr {$n * $n} }
+    } -returnCodes ok -result {}
+
+    test accumulate-2 "squares" -body {
+        accumulate n {1 2 3 4} {expr {$n * $n}}
+    } -returnCodes ok -result {1 4 9 16}
+
+    test accumulate-3 "upper case" -body {
+        accumulate word {hello world} {string toupper $word}
+    } -returnCodes ok -result {HELLO WORLD}
+
+    proc divmod {num div} {
+        return [list [expr {$num / $div}] [expr {$num % $div}]]
+    }
+
+    set numbers {10 17 23}
+
+    test accumulate-4 "divmod" -body {
+        accumulate n $numbers {divmod $n 7}
+    } -returnCodes ok -result {{1 3} {2 3} {3 2}}
+
+    test accumulate-5 "composition" -body {
+        accumulate pair [accumulate n $numbers {divmod $n 7}] {
+            lassign $pair quotient remainder
+            expr {7 * $quotient + $remainder}
+        }
+    } -returnCodes ok -result $numbers
+
+    test accumulate-6 "recursive" -body {
+        accumulate char {a b c} {
+            accumulate digit {1 2 3} {
+                string cat $char $digit
+            }
+        }
+    } -returnCodes ok -result {{a1 a2 a3} {b1 b2 b3} {c1 c2 c3}}
+
+    test accumulate-8 "prefix of list" -body {
+        accumulate n {7 6 5 4 3 2 1} {
+            if {$n == 3} {
+                break
+            } else {
+                set n
+            }
+        }
+    } -returnCodes ok -result {7 6 5 4}
+
+    test accumulate-7 "filter" -body {
+        accumulate n {1 2 3 4 5 6 7} {expr {$n % 2 == 0 ? $n : [continue]}}
+    } -returnCodes ok -result {2 4 6}
+
+    test accumulate-9 "does not modify original list" -body {
+        set original {1 2 3}
+        set accumulated [accumulate n $original {incr n}]
+        list $accumulated $original
+    } -returnCodes ok -result {{2 3 4} {1 2 3}}
+
+    cleanupTests
+}

--- a/scripts/pr
+++ b/scripts/pr
@@ -15,11 +15,11 @@ declare -A seen=()
 status=0
 
 for file; do
-    dir=$(dirname "$file")
-
-    # The example.tcl script lives in the exercises/practice/[exercise]/.meta
-    # directory.  We want to strip that off:
-    dir=${dir%/.meta}
+    # find the first 3 parts of the path.
+    # e.g. if $file is "exercises/practice/hello-world/.meta/example.tcl
+    # then $dir should be "exercises/practice/hello-world" 
+    IFS=/ read -ra path <<<"$file"
+    dir=$(IFS="/"; echo "${path[*]:0:3}")
 
     if [[ ! -v seen["$dir"] ]]; then
         seen["$dir"]=1


### PR DESCRIPTION
Reverses PR #176 

It was short-sighted to remove it: it's a useful exercise for learning the `upvar` and `uplevel` commands, and how easy it is to write control flow procedures in Tcl