### PR TITLE
🤖 Simplify tests.toml files

### DIFF
--- a/exercises/practice/acronym/.meta/tests.toml
+++ b/exercises/practice/acronym/.meta/tests.toml
@@ -4,36 +4,27 @@
 
 [1e22cceb-c5e4-4562-9afe-aef07ad1eaf4]
 description = "basic"
-include = true
 
 [79ae3889-a5c0-4b01-baf0-232d31180c08]
 description = "lowercase words"
-include = true
 
 [ec7000a7-3931-4a17-890e-33ca2073a548]
 description = "punctuation"
-include = true
 
 [32dd261c-0c92-469a-9c5c-b192e94a63b0]
 description = "all caps word"
-include = true
 
 [ae2ac9fa-a606-4d05-8244-3bcc4659c1d4]
 description = "punctuation without whitespace"
-include = true
 
 [0e4b1e7c-1a6d-48fb-81a7-bf65eb9e69f9]
 description = "very long abbreviation"
-include = true
 
 [6a078f49-c68d-4b7b-89af-33a1a98c28cc]
 description = "consecutive delimiters"
-include = true
 
 [5118b4b1-4572-434c-8d57-5b762e57973e]
 description = "apostrophes"
-include = true
 
 [adc12eab-ec2d-414f-b48c-66a4fc06cdef]
 description = "underscore emphasis"
-include = true

--- a/exercises/practice/affine-cipher/.meta/tests.toml
+++ b/exercises/practice/affine-cipher/.meta/tests.toml
@@ -4,64 +4,48 @@
 
 [2ee1d9af-1c43-416c-b41b-cefd7d4d2b2a]
 description = "encode yes"
-include = true
 
 [785bade9-e98b-4d4f-a5b0-087ba3d7de4b]
 description = "encode no"
-include = true
 
 [2854851c-48fb-40d8-9bf6-8f192ed25054]
 description = "encode OMG"
-include = true
 
 [bc0c1244-b544-49dd-9777-13a770be1bad]
 description = "encode O M G"
-include = true
 
 [381a1a20-b74a-46ce-9277-3778625c9e27]
 description = "encode mindblowingly"
-include = true
 
 [6686f4e2-753b-47d4-9715-876fdc59029d]
 description = "encode numbers"
-include = true
 
 [ae23d5bd-30a8-44b6-afbe-23c8c0c7faa3]
 description = "encode deep thought"
-include = true
 
 [c93a8a4d-426c-42ef-9610-76ded6f7ef57]
 description = "encode all the letters"
-include = true
 
 [0673638a-4375-40bd-871c-fb6a2c28effb]
 description = "encode with a not coprime to m"
-include = true
 
 [3f0ac7e2-ec0e-4a79-949e-95e414953438]
 description = "decode exercism"
-include = true
 
 [241ee64d-5a47-4092-a5d7-7939d259e077]
 description = "decode a sentence"
-include = true
 
 [33fb16a1-765a-496f-907f-12e644837f5e]
 description = "decode numbers"
-include = true
 
 [20bc9dce-c5ec-4db6-a3f1-845c776bcbf7]
 description = "decode all the letters"
-include = true
 
 [623e78c0-922d-49c5-8702-227a3e8eaf81]
 description = "decode with no spaces in input"
-include = true
 
 [58fd5c2a-1fd9-4563-a80a-71cff200f26f]
 description = "decode with too many spaces"
-include = true
 
 [b004626f-c186-4af9-a3f4-58f74cdb86d5]
 description = "decode with a not coprime to m"
-include = true

--- a/exercises/practice/all-your-base/.meta/tests.toml
+++ b/exercises/practice/all-your-base/.meta/tests.toml
@@ -4,84 +4,63 @@
 
 [5ce422f9-7a4b-4f44-ad29-49c67cb32d2c]
 description = "single bit one to decimal"
-include = true
 
 [0cc3fea8-bb79-46ac-a2ab-5a2c93051033]
 description = "binary to single decimal"
-include = true
 
 [f12db0f9-0d3d-42c2-b3ba-e38cb375a2b8]
 description = "single decimal to binary"
-include = true
 
 [2c45cf54-6da3-4748-9733-5a3c765d925b]
 description = "binary to multiple decimal"
-include = true
 
 [65ddb8b4-8899-4fcc-8618-181b2cf0002d]
 description = "decimal to binary"
-include = true
 
 [8d418419-02a7-4824-8b7a-352d33c6987e]
 description = "trinary to hexadecimal"
-include = true
 
 [d3901c80-8190-41b9-bd86-38d988efa956]
 description = "hexadecimal to trinary"
-include = true
 
 [5d42f85e-21ad-41bd-b9be-a3e8e4258bbf]
 description = "15-bit integer"
-include = true
 
 [d68788f7-66dd-43f8-a543-f15b6d233f83]
 description = "empty list"
-include = true
 
 [5e27e8da-5862-4c5f-b2a9-26c0382b6be7]
 description = "single zero"
-include = true
 
 [2e1c2573-77e4-4b9c-8517-6c56c5bcfdf2]
 description = "multiple zeros"
-include = true
 
 [3530cd9f-8d6d-43f5-bc6e-b30b1db9629b]
 description = "leading zeros"
-include = true
 
 [a6b476a1-1901-4f2a-92c4-4d91917ae023]
 description = "input base is one"
-include = true
 
 [e21a693a-7a69-450b-b393-27415c26a016]
 description = "input base is zero"
-include = true
 
 [54a23be5-d99e-41cc-88e0-a650ffe5fcc2]
 description = "input base is negative"
-include = true
 
 [9eccf60c-dcc9-407b-95d8-c37b8be56bb6]
 description = "negative digit"
-include = true
 
 [232fa4a5-e761-4939-ba0c-ed046cd0676a]
 description = "invalid positive digit"
-include = true
 
 [14238f95-45da-41dc-95ce-18f860b30ad3]
 description = "output base is one"
-include = true
 
 [73dac367-da5c-4a37-95fe-c87fad0a4047]
 description = "output base is zero"
-include = true
 
 [13f81f42-ff53-4e24-89d9-37603a48ebd9]
 description = "output base is negative"
-include = true
 
 [0e6c895d-8a5d-4868-a345-309d094cfe8d]
 description = "both bases are negative"
-include = true

--- a/exercises/practice/allergies/.meta/tests.toml
+++ b/exercises/practice/allergies/.meta/tests.toml
@@ -4,196 +4,147 @@
 
 [17fc7296-2440-4ac4-ad7b-d07c321bc5a0]
 description = "not allergic to anything"
-include = true
 
 [07ced27b-1da5-4c2e-8ae2-cb2791437546]
 description = "allergic only to eggs"
-include = true
 
 [5035b954-b6fa-4b9b-a487-dae69d8c5f96]
 description = "allergic to eggs and something else"
-include = true
 
 [64a6a83a-5723-4b5b-a896-663307403310]
 description = "allergic to something, but not eggs"
-include = true
 
 [90c8f484-456b-41c4-82ba-2d08d93231c6]
 description = "allergic to everything"
-include = true
 
 [d266a59a-fccc-413b-ac53-d57cb1f0db9d]
 description = "not allergic to anything"
-include = true
 
 [ea210a98-860d-46b2-a5bf-50d8995b3f2a]
 description = "allergic only to peanuts"
-include = true
 
 [eac69ae9-8d14-4291-ac4b-7fd2c73d3a5b]
 description = "allergic to peanuts and something else"
-include = true
 
 [9152058c-ce39-4b16-9b1d-283ec6d25085]
 description = "allergic to something, but not peanuts"
-include = true
 
 [d2d71fd8-63d5-40f9-a627-fbdaf88caeab]
 description = "allergic to everything"
-include = true
 
 [b948b0a1-cbf7-4b28-a244-73ff56687c80]
 description = "not allergic to anything"
-include = true
 
 [9ce9a6f3-53e9-4923-85e0-73019047c567]
 description = "allergic only to shellfish"
-include = true
 
 [b272fca5-57ba-4b00-bd0c-43a737ab2131]
 description = "allergic to shellfish and something else"
-include = true
 
 [21ef8e17-c227-494e-8e78-470a1c59c3d8]
 description = "allergic to something, but not shellfish"
-include = true
 
 [cc789c19-2b5e-4c67-b146-625dc8cfa34e]
 description = "allergic to everything"
-include = true
 
 [651bde0a-2a74-46c4-ab55-02a0906ca2f5]
 description = "not allergic to anything"
-include = true
 
 [b649a750-9703-4f5f-b7f7-91da2c160ece]
 description = "allergic only to strawberries"
-include = true
 
 [50f5f8f3-3bac-47e6-8dba-2d94470a4bc6]
 description = "allergic to strawberries and something else"
-include = true
 
 [23dd6952-88c9-48d7-a7d5-5d0343deb18d]
 description = "allergic to something, but not strawberries"
-include = true
 
 [74afaae2-13b6-43a2-837a-286cd42e7d7e]
 description = "allergic to everything"
-include = true
 
 [c49a91ef-6252-415e-907e-a9d26ef61723]
 description = "not allergic to anything"
-include = true
 
 [b69c5131-b7d0-41ad-a32c-e1b2cc632df8]
 description = "allergic only to tomatoes"
-include = true
 
 [1ca50eb1-f042-4ccf-9050-341521b929ec]
 description = "allergic to tomatoes and something else"
-include = true
 
 [e9846baa-456b-4eff-8025-034b9f77bd8e]
 description = "allergic to something, but not tomatoes"
-include = true
 
 [b2414f01-f3ad-4965-8391-e65f54dad35f]
 description = "allergic to everything"
-include = true
 
 [978467ab-bda4-49f7-b004-1d011ead947c]
 description = "not allergic to anything"
-include = true
 
 [59cf4e49-06ea-4139-a2c1-d7aad28f8cbc]
 description = "allergic only to chocolate"
-include = true
 
 [b0a7c07b-2db7-4f73-a180-565e07040ef1]
 description = "allergic to chocolate and something else"
-include = true
 
 [f5506893-f1ae-482a-b516-7532ba5ca9d2]
 description = "allergic to something, but not chocolate"
-include = true
 
 [02debb3d-d7e2-4376-a26b-3c974b6595c6]
 description = "allergic to everything"
-include = true
 
 [17f4a42b-c91e-41b8-8a76-4797886c2d96]
 description = "not allergic to anything"
-include = true
 
 [7696eba7-1837-4488-882a-14b7b4e3e399]
 description = "allergic only to pollen"
-include = true
 
 [9a49aec5-fa1f-405d-889e-4dfc420db2b6]
 description = "allergic to pollen and something else"
-include = true
 
 [3cb8e79f-d108-4712-b620-aa146b1954a9]
 description = "allergic to something, but not pollen"
-include = true
 
 [1dc3fe57-7c68-4043-9d51-5457128744b2]
 description = "allergic to everything"
-include = true
 
 [d3f523d6-3d50-419b-a222-d4dfd62ce314]
 description = "not allergic to anything"
-include = true
 
 [eba541c3-c886-42d3-baef-c048cb7fcd8f]
 description = "allergic only to cats"
-include = true
 
 [ba718376-26e0-40b7-bbbe-060287637ea5]
 description = "allergic to cats and something else"
-include = true
 
 [3c6dbf4a-5277-436f-8b88-15a206f2d6c4]
 description = "allergic to something, but not cats"
-include = true
 
 [1faabb05-2b98-4995-9046-d83e4a48a7c1]
 description = "allergic to everything"
-include = true
 
 [f9c1b8e7-7dc5-4887-aa93-cebdcc29dd8f]
 description = "no allergies"
-include = true
 
 [9e1a4364-09a6-4d94-990f-541a94a4c1e8]
 description = "just eggs"
-include = true
 
 [8851c973-805e-4283-9e01-d0c0da0e4695]
 description = "just peanuts"
-include = true
 
 [2c8943cb-005e-435f-ae11-3e8fb558ea98]
 description = "just strawberries"
-include = true
 
 [6fa95d26-044c-48a9-8a7b-9ee46ec32c5c]
 description = "eggs and peanuts"
-include = true
 
 [19890e22-f63f-4c5c-a9fb-fb6eacddfe8e]
 description = "more than eggs but not peanuts"
-include = true
 
 [4b68f470-067c-44e4-889f-c9fe28917d2f]
 description = "lots of stuff"
-include = true
 
 [0881b7c5-9efa-4530-91bd-68370d054bc7]
 description = "everything"
-include = true
 
 [12ce86de-b347-42a0-ab7c-2e0570f0c65b]
 description = "no allergen score parts"
-include = true

--- a/exercises/practice/alphametics/.meta/tests.toml
+++ b/exercises/practice/alphametics/.meta/tests.toml
@@ -4,40 +4,30 @@
 
 [e0c08b07-9028-4d5f-91e1-d178fead8e1a]
 description = "puzzle with three letters"
-include = true
 
 [a504ee41-cb92-4ec2-9f11-c37e95ab3f25]
 description = "solution must have unique value for each letter"
-include = true
 
 [4e3b81d2-be7b-4c5c-9a80-cd72bc6d465a]
 description = "leading zero solution is invalid"
-include = true
 
 [8a3e3168-d1ee-4df7-94c7-b9c54845ac3a]
 description = "puzzle with two digits final carry"
-include = true
 
 [a9630645-15bd-48b6-a61e-d85c4021cc09]
 description = "puzzle with four letters"
-include = true
 
 [3d905a86-5a52-4e4e-bf80-8951535791bd]
 description = "puzzle with six letters"
-include = true
 
 [4febca56-e7b7-4789-97b9-530d09ba95f0]
 description = "puzzle with seven letters"
-include = true
 
 [12125a75-7284-4f9a-a5fa-191471e0d44f]
 description = "puzzle with eight letters"
-include = true
 
 [fb05955f-38dc-477a-a0b6-5ef78969fffa]
 description = "puzzle with ten letters"
-include = true
 
 [9a101e81-9216-472b-b458-b513a7adacf7]
 description = "puzzle with ten letters and 199 addends"
-include = true

--- a/exercises/practice/anagram/.meta/tests.toml
+++ b/exercises/practice/anagram/.meta/tests.toml
@@ -4,56 +4,42 @@
 
 [dd40c4d2-3c8b-44e5-992a-f42b393ec373]
 description = "no matches"
-include = true
 
 [b3cca662-f50a-489e-ae10-ab8290a09bdc]
 description = "detects two anagrams"
-include = true
 
 [a27558ee-9ba0-4552-96b1-ecf665b06556]
 description = "does not detect anagram subsets"
-include = true
 
 [64cd4584-fc15-4781-b633-3d814c4941a4]
 description = "detects anagram"
-include = true
 
 [99c91beb-838f-4ccd-b123-935139917283]
 description = "detects three anagrams"
-include = true
 
 [78487770-e258-4e1f-a646-8ece10950d90]
 description = "detects multiple anagrams with different case"
-include = true
 
 [1d0ab8aa-362f-49b7-9902-3d0c668d557b]
 description = "does not detect non-anagrams with identical checksum"
-include = true
 
 [9e632c0b-c0b1-4804-8cc1-e295dea6d8a8]
 description = "detects anagrams case-insensitively"
-include = true
 
 [b248e49f-0905-48d2-9c8d-bd02d8c3e392]
 description = "detects anagrams using case-insensitive subject"
-include = true
 
 [f367325c-78ec-411c-be76-e79047f4bd54]
 description = "detects anagrams using case-insensitive possible matches"
-include = true
 
 [7cc195ad-e3c7-44ee-9fd2-d3c344806a2c]
 description = "does not detect an anagram if the original word is repeated"
-include = true
 
 [9878a1c9-d6ea-4235-ae51-3ea2befd6842]
 description = "anagrams must use all letters exactly once"
-include = true
 
 [85757361-4535-45fd-ac0e-3810d40debc1]
 description = "words are not anagrams of themselves (case-insensitive)"
-include = true
 
 [a0705568-628c-4b55-9798-82e4acde51ca]
 description = "words other than themselves can be anagrams"
-include = true

--- a/exercises/practice/armstrong-numbers/.meta/tests.toml
+++ b/exercises/practice/armstrong-numbers/.meta/tests.toml
@@ -4,36 +4,27 @@
 
 [c1ed103c-258d-45b2-be73-d8c6d9580c7b]
 description = "Zero is an Armstrong number"
-include = true
 
 [579e8f03-9659-4b85-a1a2-d64350f6b17a]
 description = "Single digit numbers are Armstrong numbers"
-include = true
 
 [2d6db9dc-5bf8-4976-a90b-b2c2b9feba60]
 description = "There are no 2 digit Armstrong numbers"
-include = true
 
 [509c087f-e327-4113-a7d2-26a4e9d18283]
 description = "Three digit number that is an Armstrong number"
-include = true
 
 [7154547d-c2ce-468d-b214-4cb953b870cf]
 description = "Three digit number that is not an Armstrong number"
-include = true
 
 [6bac5b7b-42e9-4ecb-a8b0-4832229aa103]
 description = "Four digit number that is an Armstrong number"
-include = true
 
 [eed4b331-af80-45b5-a80b-19c9ea444b2e]
 description = "Four digit number that is not an Armstrong number"
-include = true
 
 [f971ced7-8d68-4758-aea1-d4194900b864]
 description = "Seven digit number that is an Armstrong number"
-include = true
 
 [7ee45d52-5d35-4fbd-b6f1-5c8cd8a67f18]
 description = "Seven digit number that is not an Armstrong number"
-include = true

--- a/exercises/practice/atbash-cipher/.meta/tests.toml
+++ b/exercises/practice/atbash-cipher/.meta/tests.toml
@@ -4,56 +4,42 @@
 
 [2f47ebe1-eab9-4d6b-b3c6-627562a31c77]
 description = "encode yes"
-include = true
 
 [b4ffe781-ea81-4b74-b268-cc58ba21c739]
 description = "encode no"
-include = true
 
 [10e48927-24ab-4c4d-9d3f-3067724ace00]
 description = "encode OMG"
-include = true
 
 [d59b8bc3-509a-4a9a-834c-6f501b98750b]
 description = "encode spaces"
-include = true
 
 [31d44b11-81b7-4a94-8b43-4af6a2449429]
 description = "encode mindblowingly"
-include = true
 
 [d503361a-1433-48c0-aae0-d41b5baa33ff]
 description = "encode numbers"
-include = true
 
 [79c8a2d5-0772-42d4-b41b-531d0b5da926]
 description = "encode deep thought"
-include = true
 
 [9ca13d23-d32a-4967-a1fd-6100b8742bab]
 description = "encode all the letters"
-include = true
 
 [bb50e087-7fdf-48e7-9223-284fe7e69851]
 description = "decode exercism"
-include = true
 
 [ac021097-cd5d-4717-8907-b0814b9e292c]
 description = "decode a sentence"
-include = true
 
 [18729de3-de74-49b8-b68c-025eaf77f851]
 description = "decode numbers"
-include = true
 
 [0f30325f-f53b-415d-ad3e-a7a4f63de034]
 description = "decode all the letters"
-include = true
 
 [39640287-30c6-4c8c-9bac-9d613d1a5674]
 description = "decode with too many spaces"
-include = true
 
 [b34edf13-34c0-49b5-aa21-0768928000d5]
 description = "decode with no spaces"
-include = true

--- a/exercises/practice/beer-song/.meta/tests.toml
+++ b/exercises/practice/beer-song/.meta/tests.toml
@@ -4,32 +4,24 @@
 
 [5a02fd08-d336-4607-8006-246fe6fa9fb0]
 description = "first generic verse"
-include = true
 
 [77299ca6-545e-4217-a9cc-606b342e0187]
 description = "last generic verse"
-include = true
 
 [102cbca0-b197-40fd-b548-e99609b06428]
 description = "verse with 2 bottles"
-include = true
 
 [b8ef9fce-960e-4d85-a0c9-980a04ec1972]
 description = "verse with 1 bottle"
-include = true
 
 [c59d4076-f671-4ee3-baaa-d4966801f90d]
 description = "verse with 0 bottles"
-include = true
 
 [7e17c794-402d-4ca6-8f96-4d8f6ee1ec7e]
 description = "first two verses"
-include = true
 
 [949868e7-67e8-43d3-9bb4-69277fe020fb]
 description = "last three verses"
-include = true
 
 [bc220626-126c-4e72-8df4-fddfc0c3e458]
 description = "all verses"
-include = true

--- a/exercises/practice/binary-search-tree/.meta/tests.toml
+++ b/exercises/practice/binary-search-tree/.meta/tests.toml
@@ -4,40 +4,30 @@
 
 [e9c93a78-c536-4750-a336-94583d23fafa]
 description = "data is retained"
-include = true
 
 [7a95c9e8-69f6-476a-b0c4-4170cb3f7c91]
 description = "smaller number at left node"
-include = true
 
 [22b89499-9805-4703-a159-1a6e434c1585]
 description = "same number at left node"
-include = true
 
 [2e85fdde-77b1-41ed-b6ac-26ce6b663e34]
 description = "greater number at right node"
-include = true
 
 [dd898658-40ab-41d0-965e-7f145bf66e0b]
 description = "can create complex tree"
-include = true
 
 [9e0c06ef-aeca-4202-b8e4-97f1ed057d56]
 description = "can sort single number"
-include = true
 
 [425e6d07-fceb-4681-a4f4-e46920e380bb]
 description = "can sort if second number is smaller than first"
-include = true
 
 [bd7532cc-6988-4259-bac8-1d50140079ab]
 description = "can sort if second number is same as first"
-include = true
 
 [b6d1b3a5-9d79-44fd-9013-c83ca92ddd36]
 description = "can sort if second number is greater than first"
-include = true
 
 [d00ec9bd-1288-4171-b968-d44d0808c1c8]
 description = "can sort complex tree"
-include = true

--- a/exercises/practice/binary-search/.meta/tests.toml
+++ b/exercises/practice/binary-search/.meta/tests.toml
@@ -4,44 +4,33 @@
 
 [b55c24a9-a98d-4379-a08c-2adcf8ebeee8]
 description = "finds a value in an array with one element"
-include = true
 
 [73469346-b0a0-4011-89bf-989e443d503d]
 description = "finds a value in the middle of an array"
-include = true
 
 [327bc482-ab85-424e-a724-fb4658e66ddb]
 description = "finds a value at the beginning of an array"
-include = true
 
 [f9f94b16-fe5e-472c-85ea-c513804c7d59]
 description = "finds a value at the end of an array"
-include = true
 
 [f0068905-26e3-4342-856d-ad153cadb338]
 description = "finds a value in an array of odd length"
-include = true
 
 [fc316b12-c8b3-4f5e-9e89-532b3389de8c]
 description = "finds a value in an array of even length"
-include = true
 
 [da7db20a-354f-49f7-a6a1-650a54998aa6]
 description = "identifies that a value is not included in the array"
-include = true
 
 [95d869ff-3daf-4c79-b622-6e805c675f97]
 description = "a value smaller than the array's smallest value is not found"
-include = true
 
 [8b24ef45-6e51-4a94-9eac-c2bf38fdb0ba]
 description = "a value larger than the array's largest value is not found"
-include = true
 
 [f439a0fa-cf42-4262-8ad1-64bf41ce566a]
 description = "nothing is found in an empty array"
-include = true
 
 [2c353967-b56d-40b8-acff-ce43115eed64]
 description = "nothing is found when the left and right bounds cross"
-include = true

--- a/exercises/practice/bob/.meta/tests.toml
+++ b/exercises/practice/bob/.meta/tests.toml
@@ -4,100 +4,75 @@
 
 [e162fead-606f-437a-a166-d051915cea8e]
 description = "stating something"
-include = true
 
 [73a966dc-8017-47d6-bb32-cf07d1a5fcd9]
 description = "shouting"
-include = true
 
 [d6c98afd-df35-4806-b55e-2c457c3ab748]
 description = "shouting gibberish"
-include = true
 
 [8a2e771d-d6f1-4e3f-b6c6-b41495556e37]
 description = "asking a question"
-include = true
 
 [81080c62-4e4d-4066-b30a-48d8d76920d9]
 description = "asking a numeric question"
-include = true
 
 [2a02716d-685b-4e2e-a804-2adaf281c01e]
 description = "asking gibberish"
-include = true
 
 [c02f9179-ab16-4aa7-a8dc-940145c385f7]
 description = "talking forcefully"
-include = true
 
 [153c0e25-9bb5-4ec5-966e-598463658bcd]
 description = "using acronyms in regular speech"
-include = true
 
 [a5193c61-4a92-4f68-93e2-f554eb385ec6]
 description = "forceful question"
-include = true
 
 [a20e0c54-2224-4dde-8b10-bd2cdd4f61bc]
 description = "shouting numbers"
-include = true
 
 [f7bc4b92-bdff-421e-a238-ae97f230ccac]
 description = "no letters"
-include = true
 
 [bb0011c5-cd52-4a5b-8bfb-a87b6283b0e2]
 description = "question with no letters"
-include = true
 
 [496143c8-1c31-4c01-8a08-88427af85c66]
 description = "shouting with special characters"
-include = true
 
 [e6793c1c-43bd-4b8d-bc11-499aea73925f]
 description = "shouting with no exclamation mark"
-include = true
 
 [aa8097cc-c548-4951-8856-14a404dd236a]
 description = "statement containing question mark"
-include = true
 
 [9bfc677d-ea3a-45f2-be44-35bc8fa3753e]
 description = "non-letters with question"
-include = true
 
 [8608c508-f7de-4b17-985b-811878b3cf45]
 description = "prattling on"
-include = true
 
 [bc39f7c6-f543-41be-9a43-fd1c2f753fc0]
 description = "silence"
-include = true
 
 [d6c47565-372b-4b09-b1dd-c40552b8378b]
 description = "prolonged silence"
-include = true
 
 [4428f28d-4100-4d85-a902-e5a78cb0ecd3]
 description = "alternate silence"
-include = true
 
 [66953780-165b-4e7e-8ce3-4bcb80b6385a]
 description = "multiple line question"
-include = true
 
 [5371ef75-d9ea-4103-bcfa-2da973ddec1b]
 description = "starting with whitespace"
-include = true
 
 [05b304d6-f83b-46e7-81e0-4cd3ca647900]
 description = "ending with whitespace"
-include = true
 
 [72bd5ad3-9b2f-4931-a988-dce1f5771de2]
 description = "other whitespace"
-include = true
 
 [12983553-8601-46a8-92fa-fcaa3bc4a2a0]
 description = "non-question ending with whitespace"
-include = true

--- a/exercises/practice/book-store/.meta/tests.toml
+++ b/exercises/practice/book-store/.meta/tests.toml
@@ -4,60 +4,45 @@
 
 [17146bd5-2e80-4557-ab4c-05632b6b0d01]
 description = "Only a single book"
-include = true
 
 [cc2de9ac-ff2a-4efd-b7c7-bfe0f43271ce]
 description = "Two of the same book"
-include = true
 
 [5a86eac0-45d2-46aa-bbf0-266b94393a1a]
 description = "Empty basket"
-include = true
 
 [158bd19a-3db4-4468-ae85-e0638a688990]
 description = "Two different books"
-include = true
 
 [f3833f6b-9332-4a1f-ad98-6c3f8e30e163]
 description = "Three different books"
-include = true
 
 [1951a1db-2fb6-4cd1-a69a-f691b6dd30a2]
 description = "Four different books"
-include = true
 
 [d70f6682-3019-4c3f-aede-83c6a8c647a3]
 description = "Five different books"
-include = true
 
 [78cacb57-911a-45f1-be52-2a5bd428c634]
 description = "Two groups of four is cheaper than group of five plus group of three"
-include = true
 
 [f808b5a4-e01f-4c0d-881f-f7b90d9739da]
 description = "Two groups of four is cheaper than groups of five and three"
-include = true
 
 [fe96401c-5268-4be2-9d9e-19b76478007c]
 description = "Group of four plus group of two is cheaper than two groups of three"
-include = true
 
 [68ea9b78-10ad-420e-a766-836a501d3633]
 description = "Two each of first 4 books and 1 copy each of rest"
-include = true
 
 [c0a779d5-a40c-47ae-9828-a340e936b866]
 description = "Two copies of each book"
-include = true
 
 [18fd86fe-08f1-4b68-969b-392b8af20513]
 description = "Three copies of first book and 2 each of remaining"
-include = true
 
 [0b19a24d-e4cf-4ec8-9db2-8899a41af0da]
 description = "Three each of first 2 books and 2 each of remaining books"
-include = true
 
 [bb376344-4fb2-49ab-ab85-e38d8354a58d]
 description = "Four groups of four are cheaper than two groups each of five and three"
-include = true

--- a/exercises/practice/bowling/.meta/tests.toml
+++ b/exercises/practice/bowling/.meta/tests.toml
@@ -4,120 +4,90 @@
 
 [656ae006-25c2-438c-a549-f338e7ec7441]
 description = "should be able to score a game with all zeros"
-include = true
 
 [f85dcc56-cd6b-4875-81b3-e50921e3597b]
 description = "should be able to score a game with no strikes or spares"
-include = true
 
 [d1f56305-3ac2-4fe0-8645-0b37e3073e20]
 description = "a spare followed by zeros is worth ten points"
-include = true
 
 [0b8c8bb7-764a-4287-801a-f9e9012f8be4]
 description = "points scored in the roll after a spare are counted twice"
-include = true
 
 [4d54d502-1565-4691-84cd-f29a09c65bea]
 description = "consecutive spares each get a one roll bonus"
-include = true
 
 [e5c9cf3d-abbe-4b74-ad48-34051b2b08c0]
 description = "a spare in the last frame gets a one roll bonus that is counted once"
-include = true
 
 [75269642-2b34-4b72-95a4-9be28ab16902]
 description = "a strike earns ten points in a frame with a single roll"
-include = true
 
 [037f978c-5d01-4e49-bdeb-9e20a2e6f9a6]
 description = "points scored in the two rolls after a strike are counted twice as a bonus"
-include = true
 
 [1635e82b-14ec-4cd1-bce4-4ea14bd13a49]
 description = "consecutive strikes each get the two roll bonus"
-include = true
 
 [e483e8b6-cb4b-4959-b310-e3982030d766]
 description = "a strike in the last frame gets a two roll bonus that is counted once"
-include = true
 
 [9d5c87db-84bc-4e01-8e95-53350c8af1f8]
 description = "rolling a spare with the two roll bonus does not get a bonus roll"
-include = true
 
 [576faac1-7cff-4029-ad72-c16bcada79b5]
 description = "strikes with the two roll bonus do not get bonus rolls"
-include = true
 
 [72e24404-b6c6-46af-b188-875514c0377b]
 description = "a strike with the one roll bonus after a spare in the last frame does not get a bonus"
-include = true
 
 [62ee4c72-8ee8-4250-b794-234f1fec17b1]
 description = "all strikes is a perfect game"
-include = true
 
 [1245216b-19c6-422c-b34b-6e4012d7459f]
 description = "rolls cannot score negative points"
-include = true
 
 [5fcbd206-782c-4faa-8f3a-be5c538ba841]
 description = "a roll cannot score more than 10 points"
-include = true
 
 [fb023c31-d842-422d-ad7e-79ce1db23c21]
 description = "two rolls in a frame cannot score more than 10 points"
-include = true
 
 [6082d689-d677-4214-80d7-99940189381b]
 description = "bonus roll after a strike in the last frame cannot score more than 10 points"
-include = true
 
 [e9565fe6-510a-4675-ba6b-733a56767a45]
 description = "two bonus rolls after a strike in the last frame cannot score more than 10 points"
-include = true
 
 [2f6acf99-448e-4282-8103-0b9c7df99c3d]
 description = "two bonus rolls after a strike in the last frame can score more than 10 points if one is a strike"
-include = true
 
 [6380495a-8bc4-4cdb-a59f-5f0212dbed01]
 description = "the second bonus rolls after a strike in the last frame cannot be a strike if the first one is not a strike"
-include = true
 
 [2b2976ea-446c-47a3-9817-42777f09fe7e]
 description = "second bonus roll after a strike in the last frame cannot score more than 10 points"
-include = true
 
 [29220245-ac8d-463d-bc19-98a94cfada8a]
 description = "an unstarted game cannot be scored"
-include = true
 
 [4473dc5d-1f86-486f-bf79-426a52ddc955]
 description = "an incomplete game cannot be scored"
-include = true
 
 [2ccb8980-1b37-4988-b7d1-e5701c317df3]
 description = "cannot roll if game already has ten frames"
-include = true
 
 [4864f09b-9df3-4b65-9924-c595ed236f1b]
 description = "bonus rolls for a strike in the last frame must be rolled before score can be calculated"
-include = true
 
 [537f4e37-4b51-4d1c-97e2-986eb37b2ac1]
 description = "both bonus rolls for a strike in the last frame must be rolled before score can be calculated"
-include = true
 
 [8134e8c1-4201-4197-bf9f-1431afcde4b9]
 description = "bonus roll for a spare in the last frame must be rolled before score can be calculated"
-include = true
 
 [9d4a9a55-134a-4bad-bae8-3babf84bd570]
 description = "cannot roll after bonus roll for spare"
-include = true
 
 [d3e02652-a799-4ae3-b53b-68582cc604be]
 description = "cannot roll after bonus rolls for strike"
-include = true

--- a/exercises/practice/change/.meta/tests.toml
+++ b/exercises/practice/change/.meta/tests.toml
@@ -4,48 +4,36 @@
 
 [d0ebd0e1-9d27-4609-a654-df5c0ba1d83a]
 description = "change for 1 cent"
-include = true
 
 [36887bea-7f92-4a9c-b0cc-c0e886b3ecc8]
 description = "single coin change"
-include = true
 
 [cef21ccc-0811-4e6e-af44-f011e7eab6c6]
 description = "multiple coin change"
-include = true
 
 [d60952bc-0c1a-4571-bf0c-41be72690cb3]
 description = "change with Lilliputian Coins"
-include = true
 
 [408390b9-fafa-4bb9-b608-ffe6036edb6c]
 description = "change with Lower Elbonia Coins"
-include = true
 
 [7421a4cb-1c48-4bf9-99c7-7f049689132f]
 description = "large target values"
-include = true
 
 [f79d2e9b-0ae3-4d6a-bb58-dc978b0dba28]
 description = "possible change without unit coins available"
-include = true
 
 [9a166411-d35d-4f7f-a007-6724ac266178]
 description = "another possible change without unit coins available"
-include = true
 
 [bbbcc154-e9e9-4209-a4db-dd6d81ec26bb]
 description = "no coins make 0 change"
-include = true
 
 [c8b81d5a-49bd-4b61-af73-8ee5383a2ce1]
 description = "error testing for change smaller than the smallest of coins"
-include = true
 
 [3c43e3e4-63f9-46ac-9476-a67516e98f68]
 description = "error if no combination can add up to target"
-include = true
 
 [8fe1f076-9b2d-4f44-89fe-8a6ccd63c8f3]
 description = "cannot find negative change values"
-include = true

--- a/exercises/practice/circular-buffer/.meta/tests.toml
+++ b/exercises/practice/circular-buffer/.meta/tests.toml
@@ -4,56 +4,42 @@
 
 [28268ed4-4ff3-45f3-820e-895b44d53dfa]
 description = "reading empty buffer should fail"
-include = true
 
 [2e6db04a-58a1-425d-ade8-ac30b5f318f3]
 description = "can read an item just written"
-include = true
 
 [90741fe8-a448-45ce-be2b-de009a24c144]
 description = "each item may only be read once"
-include = true
 
 [be0e62d5-da9c-47a8-b037-5db21827baa7]
 description = "items are read in the order they are written"
-include = true
 
 [2af22046-3e44-4235-bfe6-05ba60439d38]
 description = "full buffer can't be written to"
-include = true
 
 [547d192c-bbf0-4369-b8fa-fc37e71f2393]
 description = "a read frees up capacity for another write"
-include = true
 
 [04a56659-3a81-4113-816b-6ecb659b4471]
 description = "read position is maintained even across multiple writes"
-include = true
 
 [60c3a19a-81a7-43d7-bb0a-f07242b1111f]
 description = "items cleared out of buffer can't be read"
-include = true
 
 [45f3ae89-3470-49f3-b50e-362e4b330a59]
 description = "clear frees up capacity for another write"
-include = true
 
 [e1ac5170-a026-4725-bfbe-0cf332eddecd]
 description = "clear does nothing on empty buffer"
-include = true
 
 [9c2d4f26-3ec7-453f-a895-7e7ff8ae7b5b]
 description = "overwrite acts like write on non-full buffer"
-include = true
 
 [880f916b-5039-475c-bd5c-83463c36a147]
 description = "overwrite replaces the oldest item on full buffer"
-include = true
 
 [bfecab5b-aca1-4fab-a2b0-cd4af2b053c3]
 description = "overwrite replaces the oldest item remaining in buffer following a read"
-include = true
 
 [9cebe63a-c405-437b-8b62-e3fdc1ecec5a]
 description = "initial clear does not affect wrapping around"
-include = true

--- a/exercises/practice/clock/.meta/tests.toml
+++ b/exercises/practice/clock/.meta/tests.toml
@@ -4,208 +4,156 @@
 
 [a577bacc-106b-496e-9792-b3083ea8705e]
 description = "on the hour"
-include = true
 
 [b5d0c360-3b88-489b-8e84-68a1c7a4fa23]
 description = "past the hour"
-include = true
 
 [473223f4-65f3-46ff-a9f7-7663c7e59440]
 description = "midnight is zero hours"
-include = true
 
 [ca95d24a-5924-447d-9a96-b91c8334725c]
 description = "hour rolls over"
-include = true
 
 [f3826de0-0925-4d69-8ac8-89aea7e52b78]
 description = "hour rolls over continuously"
-include = true
 
 [a02f7edf-dfd4-4b11-b21a-86de3cc6a95c]
 description = "sixty minutes is next hour"
-include = true
 
 [8f520df6-b816-444d-b90f-8a477789beb5]
 description = "minutes roll over"
-include = true
 
 [c75c091b-47ac-4655-8d40-643767fc4eed]
 description = "minutes roll over continuously"
-include = true
 
 [06343ecb-cf39-419d-a3f5-dcbae0cc4c57]
 description = "hour and minutes roll over"
-include = true
 
 [be60810e-f5d9-4b58-9351-a9d1e90e660c]
 description = "hour and minutes roll over continuously"
-include = true
 
 [1689107b-0b5c-4bea-aad3-65ec9859368a]
 description = "hour and minutes roll over to exactly midnight"
-include = true
 
 [d3088ee8-91b7-4446-9e9d-5e2ad6219d91]
 description = "negative hour"
-include = true
 
 [77ef6921-f120-4d29-bade-80d54aa43b54]
 description = "negative hour rolls over"
-include = true
 
 [359294b5-972f-4546-bb9a-a85559065234]
 description = "negative hour rolls over continuously"
-include = true
 
 [509db8b7-ac19-47cc-bd3a-a9d2f30b03c0]
 description = "negative minutes"
-include = true
 
 [5d6bb225-130f-4084-84fd-9e0df8996f2a]
 description = "negative minutes roll over"
-include = true
 
 [d483ceef-b520-4f0c-b94a-8d2d58cf0484]
 description = "negative minutes roll over continuously"
-include = true
 
 [1cd19447-19c6-44bf-9d04-9f8305ccb9ea]
 description = "negative sixty minutes is previous hour"
-include = true
 
 [9d3053aa-4f47-4afc-bd45-d67a72cef4dc]
 description = "negative hour and minutes both roll over"
-include = true
 
 [51d41fcf-491e-4ca0-9cae-2aa4f0163ad4]
 description = "negative hour and minutes both roll over continuously"
-include = true
 
 [d098e723-ad29-4ef9-997a-2693c4c9d89a]
 description = "add minutes"
-include = true
 
 [b6ec8f38-e53e-4b22-92a7-60dab1f485f4]
 description = "add no minutes"
-include = true
 
 [efd349dd-0785-453e-9ff8-d7452a8e7269]
 description = "add to next hour"
-include = true
 
 [749890f7-aba9-4702-acce-87becf4ef9fe]
 description = "add more than one hour"
-include = true
 
 [da63e4c1-1584-46e3-8d18-c9dc802c1713]
 description = "add more than two hours with carry"
-include = true
 
 [be167a32-3d33-4cec-a8bc-accd47ddbb71]
 description = "add across midnight"
-include = true
 
 [6672541e-cdae-46e4-8be7-a820cc3be2a8]
 description = "add more than one day (1500 min = 25 hrs)"
-include = true
 
 [1918050d-c79b-4cb7-b707-b607e2745c7e]
 description = "add more than two days"
-include = true
 
 [37336cac-5ede-43a5-9026-d426cbe40354]
 description = "subtract minutes"
-include = true
 
 [0aafa4d0-3b5f-4b12-b3af-e3a9e09c047b]
 description = "subtract to previous hour"
-include = true
 
 [9b4e809c-612f-4b15-aae0-1df0acb801b9]
 description = "subtract more than an hour"
-include = true
 
 [8b04bb6a-3d33-4e6c-8de9-f5de6d2c70d6]
 description = "subtract across midnight"
-include = true
 
 [07c3bbf7-ce4d-4658-86e8-4a77b7a5ccd9]
 description = "subtract more than two hours"
-include = true
 
 [90ac8a1b-761c-4342-9c9c-cdc3ed5db097]
 description = "subtract more than two hours with borrow"
-include = true
 
 [2149f985-7136-44ad-9b29-ec023a97a2b7]
 description = "subtract more than one day (1500 min = 25 hrs)"
-include = true
 
 [ba11dbf0-ac27-4acb-ada9-3b853ec08c97]
 description = "subtract more than two days"
-include = true
 
 [f2fdad51-499f-4c9b-a791-b28c9282e311]
 description = "clocks with same time"
-include = true
 
 [5d409d4b-f862-4960-901e-ec430160b768]
 description = "clocks a minute apart"
-include = true
 
 [a6045fcf-2b52-4a47-8bb2-ef10a064cba5]
 description = "clocks an hour apart"
-include = true
 
 [66b12758-0be5-448b-a13c-6a44bce83527]
 description = "clocks with hour overflow"
-include = true
 
 [2b19960c-212e-4a71-9aac-c581592f8111]
 description = "clocks with hour overflow by several days"
-include = true
 
 [6f8c6541-afac-4a92-b0c2-b10d4e50269f]
 description = "clocks with negative hour"
-include = true
 
 [bb9d5a68-e324-4bf5-a75e-0e9b1f97a90d]
 description = "clocks with negative hour that wraps"
-include = true
 
 [56c0326d-565b-4d19-a26f-63b3205778b7]
 description = "clocks with negative hour that wraps multiple times"
-include = true
 
 [c90b9de8-ddff-4ffe-9858-da44a40fdbc2]
 description = "clocks with minute overflow"
-include = true
 
 [533a3dc5-59a7-491b-b728-a7a34fe325de]
 description = "clocks with minute overflow by several days"
-include = true
 
 [fff49e15-f7b7-4692-a204-0f6052d62636]
 description = "clocks with negative minute"
-include = true
 
 [605c65bb-21bd-43eb-8f04-878edf508366]
 description = "clocks with negative minute that wraps"
-include = true
 
 [b87e64ed-212a-4335-91fd-56da8421d077]
 description = "clocks with negative minute that wraps multiple times"
-include = true
 
 [822fbf26-1f3b-4b13-b9bf-c914816b53dd]
 description = "clocks with negative hours and minutes"
-include = true
 
 [e787bccd-cf58-4a1d-841c-ff80eaaccfaa]
 description = "clocks with negative hours and minutes that wrap"
-include = true
 
 [96969ca8-875a-48a1-86ae-257a528c44f5]
 description = "full clock and zeroed clock"
-include = true

--- a/exercises/practice/collatz-conjecture/.meta/tests.toml
+++ b/exercises/practice/collatz-conjecture/.meta/tests.toml
@@ -4,24 +4,18 @@
 
 [540a3d51-e7a6-47a5-92a3-4ad1838f0bfd]
 description = "zero steps for one"
-include = true
 
 [3d76a0a6-ea84-444a-821a-f7857c2c1859]
 description = "divide if even"
-include = true
 
 [754dea81-123c-429e-b8bc-db20b05a87b9]
 description = "even and odd steps"
-include = true
 
 [ecfd0210-6f85-44f6-8280-f65534892ff6]
 description = "large number of even and odd steps"
-include = true
 
 [7d4750e6-def9-4b86-aec7-9f7eb44f95a3]
 description = "zero is an error"
-include = true
 
 [c6c795bf-a288-45e9-86a1-841359ad426d]
 description = "negative value is an error"
-include = true

--- a/exercises/practice/complex-numbers/.meta/tests.toml
+++ b/exercises/practice/complex-numbers/.meta/tests.toml
@@ -4,124 +4,93 @@
 
 [9f98e133-eb7f-45b0-9676-cce001cd6f7a]
 description = "Real part of a purely real number"
-include = true
 
 [07988e20-f287-4bb7-90cf-b32c4bffe0f3]
 description = "Real part of a purely imaginary number"
-include = true
 
 [4a370e86-939e-43de-a895-a00ca32da60a]
 description = "Real part of a number with real and imaginary part"
-include = true
 
 [9b3fddef-4c12-4a99-b8f8-e3a42c7ccef6]
 description = "Imaginary part of a purely real number"
-include = true
 
 [a8dafedd-535a-4ed3-8a39-fda103a2b01e]
 description = "Imaginary part of a purely imaginary number"
-include = true
 
 [0f998f19-69ee-4c64-80ef-01b086feab80]
 description = "Imaginary part of a number with real and imaginary part"
-include = true
 
 [a39b7fd6-6527-492f-8c34-609d2c913879]
 description = "Imaginary unit"
-include = true
 
 [9a2c8de9-f068-4f6f-b41c-82232cc6c33e]
 description = "Add purely real numbers"
-include = true
 
 [657c55e1-b14b-4ba7-bd5c-19db22b7d659]
 description = "Add purely imaginary numbers"
-include = true
 
 [4e1395f5-572b-4ce8-bfa9-9a63056888da]
 description = "Add numbers with real and imaginary part"
-include = true
 
 [1155dc45-e4f7-44b8-af34-a91aa431475d]
 description = "Subtract purely real numbers"
-include = true
 
 [f95e9da8-acd5-4da4-ac7c-c861b02f774b]
 description = "Subtract purely imaginary numbers"
-include = true
 
 [f876feb1-f9d1-4d34-b067-b599a8746400]
 description = "Subtract numbers with real and imaginary part"
-include = true
 
 [8a0366c0-9e16-431f-9fd7-40ac46ff4ec4]
 description = "Multiply purely real numbers"
-include = true
 
 [e560ed2b-0b80-4b4f-90f2-63cefc911aaf]
 description = "Multiply purely imaginary numbers"
-include = true
 
 [4d1d10f0-f8d4-48a0-b1d0-f284ada567e6]
 description = "Multiply numbers with real and imaginary part"
-include = true
 
 [b0571ddb-9045-412b-9c15-cd1d816d36c1]
 description = "Divide purely real numbers"
-include = true
 
 [5bb4c7e4-9934-4237-93cc-5780764fdbdd]
 description = "Divide purely imaginary numbers"
-include = true
 
 [c4e7fef5-64ac-4537-91c2-c6529707701f]
 description = "Divide numbers with real and imaginary part"
-include = true
 
 [c56a7332-aad2-4437-83a0-b3580ecee843]
 description = "Absolute value of a positive purely real number"
-include = true
 
 [cf88d7d3-ee74-4f4e-8a88-a1b0090ecb0c]
 description = "Absolute value of a negative purely real number"
-include = true
 
 [bbe26568-86c1-4bb4-ba7a-da5697e2b994]
 description = "Absolute value of a purely imaginary number with positive imaginary part"
-include = true
 
 [3b48233d-468e-4276-9f59-70f4ca1f26f3]
 description = "Absolute value of a purely imaginary number with negative imaginary part"
-include = true
 
 [fe400a9f-aa22-4b49-af92-51e0f5a2a6d3]
 description = "Absolute value of a number with real and imaginary part"
-include = true
 
 [fb2d0792-e55a-4484-9443-df1eddfc84a2]
 description = "Conjugate a purely real number"
-include = true
 
 [e37fe7ac-a968-4694-a460-66cb605f8691]
 description = "Conjugate a purely imaginary number"
-include = true
 
 [f7704498-d0be-4192-aaf5-a1f3a7f43e68]
 description = "Conjugate a number with real and imaginary part"
-include = true
 
 [6d96d4c6-2edb-445b-94a2-7de6d4caaf60]
 description = "Euler's identity/formula"
-include = true
 
 [2d2c05a0-4038-4427-a24d-72f6624aa45f]
 description = "Exponential of 0"
-include = true
 
 [ed87f1bd-b187-45d6-8ece-7e331232c809]
 description = "Exponential of a purely real number"
-include = true
 
 [08eedacc-5a95-44fc-8789-1547b27a8702]
 description = "Exponential of a number with real and imaginary part"
-include = true

--- a/exercises/practice/connect/.meta/tests.toml
+++ b/exercises/practice/connect/.meta/tests.toml
@@ -4,40 +4,30 @@
 
 [6eff0df4-3e92-478d-9b54-d3e8b354db56]
 description = "an empty board has no winner"
-include = true
 
 [298b94c0-b46d-45d8-b34b-0fa2ea71f0a4]
 description = "X can win on a 1x1 board"
-include = true
 
 [763bbae0-cb8f-4f28-bc21-5be16a5722dc]
 description = "O can win on a 1x1 board"
-include = true
 
 [819fde60-9ae2-485e-a024-cbb8ea68751b]
 description = "only edges does not make a winner"
-include = true
 
 [2c56a0d5-9528-41e5-b92b-499dfe08506c]
 description = "illegal diagonal does not make a winner"
-include = true
 
 [41cce3ef-43ca-4963-970a-c05d39aa1cc1]
 description = "nobody wins crossing adjacent angles"
-include = true
 
 [cd61c143-92f6-4a8d-84d9-cb2b359e226b]
 description = "X wins crossing from left to right"
-include = true
 
 [73d1eda6-16ab-4460-9904-b5f5dd401d0b]
 description = "O wins crossing from top to bottom"
-include = true
 
 [c3a2a550-944a-4637-8b3f-1e1bf1340a3d]
 description = "X wins using a convoluted path"
-include = true
 
 [17e76fa8-f731-4db7-92ad-ed2a285d31f3]
 description = "X wins using a spiral path"
-include = true

--- a/exercises/practice/crypto-square/.meta/tests.toml
+++ b/exercises/practice/crypto-square/.meta/tests.toml
@@ -4,28 +4,21 @@
 
 [407c3837-9aa7-4111-ab63-ec54b58e8e9f]
 description = "empty plaintext results in an empty ciphertext"
-include = true
 
 [64131d65-6fd9-4f58-bdd8-4a2370fb481d]
 description = "Lowercase"
-include = true
 
 [63a4b0ed-1e3c-41ea-a999-f6f26ba447d6]
 description = "Remove spaces"
-include = true
 
 [1b5348a1-7893-44c1-8197-42d48d18756c]
 description = "Remove punctuation"
-include = true
 
 [8574a1d3-4a08-4cec-a7c7-de93a164f41a]
 description = "9 character plaintext results in 3 chunks of 3 characters"
-include = true
 
 [a65d3fa1-9e09-43f9-bcec-7a672aec3eae]
 description = "8 character plaintext results in 3 chunks, the last one with a trailing space"
-include = true
 
 [fbcb0c6d-4c39-4a31-83f6-c473baa6af80]
 description = "54 character plaintext results in 7 chunks, the last two with trailing spaces"
-include = true

--- a/exercises/practice/custom-set/.meta/tests.toml
+++ b/exercises/practice/custom-set/.meta/tests.toml
@@ -4,152 +4,114 @@
 
 [20c5f855-f83a-44a7-abdd-fe75c6cf022b]
 description = "sets with no elements are empty"
-include = true
 
 [d506485d-5706-40db-b7d8-5ceb5acf88d2]
 description = "sets with elements are not empty"
-include = true
 
 [759b9740-3417-44c3-8ca3-262b3c281043]
 description = "nothing is contained in an empty set"
-include = true
 
 [f83cd2d1-2a85-41bc-b6be-80adbff4be49]
 description = "when the element is in the set"
-include = true
 
 [93423fc0-44d0-4bc0-a2ac-376de8d7af34]
 description = "when the element is not in the set"
-include = true
 
 [c392923a-637b-4495-b28e-34742cd6157a]
 description = "empty set is a subset of another empty set"
-include = true
 
 [5635b113-be8c-4c6f-b9a9-23c485193917]
 description = "empty set is a subset of non-empty set"
-include = true
 
 [832eda58-6d6e-44e2-92c2-be8cf0173cee]
 description = "non-empty set is not a subset of empty set"
-include = true
 
 [c830c578-8f97-4036-b082-89feda876131]
 description = "set is a subset of set with exact same elements"
-include = true
 
 [476a4a1c-0fd1-430f-aa65-5b70cbc810c5]
 description = "set is a subset of larger set with same elements"
-include = true
 
 [d2498999-3e46-48e4-9660-1e20c3329d3d]
 description = "set is not a subset of set that does not contain its elements"
-include = true
 
 [7d38155e-f472-4a7e-9ad8-5c1f8f95e4cc]
 description = "the empty set is disjoint with itself"
-include = true
 
 [7a2b3938-64b6-4b32-901a-fe16891998a6]
 description = "empty set is disjoint with non-empty set"
-include = true
 
 [589574a0-8b48-48ea-88b0-b652c5fe476f]
 description = "non-empty set is disjoint with empty set"
-include = true
 
 [febeaf4f-f180-4499-91fa-59165955a523]
 description = "sets are not disjoint if they share an element"
-include = true
 
 [0de20d2f-c952-468a-88c8-5e056740f020]
 description = "sets are disjoint if they share no elements"
-include = true
 
 [4bd24adb-45da-4320-9ff6-38c044e9dff8]
 description = "empty sets are equal"
-include = true
 
 [f65c0a0e-6632-4b2d-b82c-b7c6da2ec224]
 description = "empty set is not equal to non-empty set"
-include = true
 
 [81e53307-7683-4b1e-a30c-7e49155fe3ca]
 description = "non-empty set is not equal to empty set"
-include = true
 
 [d57c5d7c-a7f3-48cc-a162-6b488c0fbbd0]
 description = "sets with the same elements are equal"
-include = true
 
 [dd61bafc-6653-42cc-961a-ab071ee0ee85]
 description = "sets with different elements are not equal"
-include = true
 
 [06059caf-9bf4-425e-aaff-88966cb3ea14]
 description = "set is not equal to larger set with same elements"
-include = true
 
 [8a677c3c-a658-4d39-bb88-5b5b1a9659f4]
 description = "add to empty set"
-include = true
 
 [0903dd45-904d-4cf2-bddd-0905e1a8d125]
 description = "add to non-empty set"
-include = true
 
 [b0eb7bb7-5e5d-4733-b582-af771476cb99]
 description = "adding an existing element does not change the set"
-include = true
 
 [893d5333-33b8-4151-a3d4-8f273358208a]
 description = "intersection of two empty sets is an empty set"
-include = true
 
 [d739940e-def2-41ab-a7bb-aaf60f7d782c]
 description = "intersection of an empty set and non-empty set is an empty set"
-include = true
 
 [3607d9d8-c895-4d6f-ac16-a14956e0a4b7]
 description = "intersection of a non-empty set and an empty set is an empty set"
-include = true
 
 [b5120abf-5b5e-41ab-aede-4de2ad85c34e]
 description = "intersection of two sets with no shared elements is an empty set"
-include = true
 
 [af21ca1b-fac9-499c-81c0-92a591653d49]
 description = "intersection of two sets with shared elements is a set of the shared elements"
-include = true
 
 [c5e6e2e4-50e9-4bc2-b89f-c518f015b57e]
 description = "difference of two empty sets is an empty set"
-include = true
 
 [2024cc92-5c26-44ed-aafd-e6ca27d6fcd2]
 description = "difference of empty set and non-empty set is an empty set"
-include = true
 
 [e79edee7-08aa-4c19-9382-f6820974b43e]
 description = "difference of a non-empty set and an empty set is the non-empty set"
-include = true
 
 [c5ac673e-d707-4db5-8d69-7082c3a5437e]
 description = "difference of two non-empty sets is a set of elements that are only in the first set"
-include = true
 
 [c45aed16-5494-455a-9033-5d4c93589dc6]
 description = "union of empty sets is an empty set"
-include = true
 
 [9d258545-33c2-4fcb-a340-9f8aa69e7a41]
 description = "union of an empty set and non-empty set is the non-empty set"
-include = true
 
 [3aade50c-80c7-4db8-853d-75bac5818b83]
 description = "union of a non-empty set and empty set is the non-empty set"
-include = true
 
 [a00bb91f-c4b4-4844-8f77-c73e2e9df77c]
 description = "union of non-empty sets contains all unique elements"
-include = true

--- a/exercises/practice/darts/.meta/tests.toml
+++ b/exercises/practice/darts/.meta/tests.toml
@@ -4,52 +4,39 @@
 
 [9033f731-0a3a-4d9c-b1c0-34a1c8362afb]
 description = "Missed target"
-include = true
 
 [4c9f6ff4-c489-45fd-be8a-1fcb08b4d0ba]
 description = "On the outer circle"
-include = true
 
 [14378687-ee58-4c9b-a323-b089d5274be8]
 description = "On the middle circle"
-include = true
 
 [849e2e63-85bd-4fed-bc3b-781ae962e2c9]
 description = "On the inner circle"
-include = true
 
 [1c5ffd9f-ea66-462f-9f06-a1303de5a226]
 description = "Exactly on centre"
-include = true
 
 [b65abce3-a679-4550-8115-4b74bda06088]
 description = "Near the centre"
-include = true
 
 [66c29c1d-44f5-40cf-9927-e09a1305b399]
 description = "Just within the inner circle"
-include = true
 
 [d1012f63-c97c-4394-b944-7beb3d0b141a]
 description = "Just outside the inner circle"
-include = true
 
 [ab2b5666-b0b4-49c3-9b27-205e790ed945]
 description = "Just within the middle circle"
-include = true
 
 [70f1424e-d690-4860-8caf-9740a52c0161]
 description = "Just outside the middle circle"
-include = true
 
 [a7dbf8db-419c-4712-8a7f-67602b69b293]
 description = "Just within the outer circle"
-include = true
 
 [e0f39315-9f9a-4546-96e4-a9475b885aa7]
 description = "Just outside the outer circle"
-include = true
 
 [045d7d18-d863-4229-818e-b50828c75d19]
 description = "Asymmetric position between the inner and middle circles"
-include = true

--- a/exercises/practice/diamond/.meta/tests.toml
+++ b/exercises/practice/diamond/.meta/tests.toml
@@ -4,20 +4,15 @@
 
 [202fb4cc-6a38-4883-9193-a29d5cb92076]
 description = "Degenerate case with a single 'A' row"
-include = true
 
 [bd6a6d78-9302-42e9-8f60-ac1461e9abae]
 description = "Degenerate case with no row containing 3 distinct groups of spaces"
-include = true
 
 [af8efb49-14ed-447f-8944-4cc59ce3fd76]
 description = "Smallest non-degenerate case with odd diamond side length"
-include = true
 
 [e0c19a95-9888-4d05-86a0-fa81b9e70d1d]
 description = "Smallest non-degenerate case with even diamond side length"
-include = true
 
 [82ea9aa9-4c0e-442a-b07e-40204e925944]
 description = "Largest possible diamond"
-include = true

--- a/exercises/practice/difference-of-squares/.meta/tests.toml
+++ b/exercises/practice/difference-of-squares/.meta/tests.toml
@@ -4,36 +4,27 @@
 
 [e46c542b-31fc-4506-bcae-6b62b3268537]
 description = "square of sum 1"
-include = true
 
 [9b3f96cb-638d-41ee-99b7-b4f9c0622948]
 description = "square of sum 5"
-include = true
 
 [54ba043f-3c35-4d43-86ff-3a41625d5e86]
 description = "square of sum 100"
-include = true
 
 [01d84507-b03e-4238-9395-dd61d03074b5]
 description = "sum of squares 1"
-include = true
 
 [c93900cd-8cc2-4ca4-917b-dd3027023499]
 description = "sum of squares 5"
-include = true
 
 [94807386-73e4-4d9e-8dec-69eb135b19e4]
 description = "sum of squares 100"
-include = true
 
 [44f72ae6-31a7-437f-858d-2c0837adabb6]
 description = "difference of squares 1"
-include = true
 
 [005cb2bf-a0c8-46f3-ae25-924029f8b00b]
 description = "difference of squares 5"
-include = true
 
 [b1bf19de-9a16-41c0-a62b-1f02ecc0b036]
 description = "difference of squares 100"
-include = true

--- a/exercises/practice/diffie-hellman/.meta/tests.toml
+++ b/exercises/practice/diffie-hellman/.meta/tests.toml
@@ -4,24 +4,18 @@
 
 [1b97bf38-4307-418e-bfd2-446ffc77588d]
 description = "private key is greater than 1 and less than p"
-include = true
 
 [68b2a5f7-7755-44c3-97b2-d28d21f014a9]
 description = "private key is random"
-include = true
 
 [b4161d8e-53a1-4241-ae8f-48cc86527f22]
 description = "can calculate public key using private key"
-include = true
 
 [0d25f8d7-4897-4338-a033-2d3d7a9af688]
 description = "can calculate public key when given a different private key"
-include = true
 
 [cd02ad45-3f52-4510-99cc-5161dad948a8]
 description = "can calculate secret using other party's public key"
-include = true
 
 [17f13c61-a111-4075-9a1f-c2d4636dfa60]
 description = "key exchange"
-include = true

--- a/exercises/practice/dnd-character/.meta/tests.toml
+++ b/exercises/practice/dnd-character/.meta/tests.toml
@@ -4,76 +4,57 @@
 
 [1e9ae1dc-35bd-43ba-aa08-e4b94c20fa37]
 description = "ability modifier for score 3 is -4"
-include = true
 
 [cc9bb24e-56b8-4e9e-989d-a0d1a29ebb9c]
 description = "ability modifier for score 4 is -3"
-include = true
 
 [5b519fcd-6946-41ee-91fe-34b4f9808326]
 description = "ability modifier for score 5 is -3"
-include = true
 
 [dc2913bd-6d7a-402e-b1e2-6d568b1cbe21]
 description = "ability modifier for score 6 is -2"
-include = true
 
 [099440f5-0d66-4b1a-8a10-8f3a03cc499f]
 description = "ability modifier for score 7 is -2"
-include = true
 
 [cfda6e5c-3489-42f0-b22b-4acb47084df0]
 description = "ability modifier for score 8 is -1"
-include = true
 
 [c70f0507-fa7e-4228-8463-858bfbba1754]
 description = "ability modifier for score 9 is -1"
-include = true
 
 [6f4e6c88-1cd9-46a0-92b8-db4a99b372f7]
 description = "ability modifier for score 10 is 0"
-include = true
 
 [e00d9e5c-63c8-413f-879d-cd9be9697097]
 description = "ability modifier for score 11 is 0"
-include = true
 
 [eea06f3c-8de0-45e7-9d9d-b8cab4179715]
 description = "ability modifier for score 12 is +1"
-include = true
 
 [9c51f6be-db72-4af7-92ac-b293a02c0dcd]
 description = "ability modifier for score 13 is +1"
-include = true
 
 [94053a5d-53b6-4efc-b669-a8b5098f7762]
 description = "ability modifier for score 14 is +2"
-include = true
 
 [8c33e7ca-3f9f-4820-8ab3-65f2c9e2f0e2]
 description = "ability modifier for score 15 is +2"
-include = true
 
 [c3ec871e-1791-44d0-b3cc-77e5fb4cd33d]
 description = "ability modifier for score 16 is +3"
-include = true
 
 [3d053cee-2888-4616-b9fd-602a3b1efff4]
 description = "ability modifier for score 17 is +3"
-include = true
 
 [bafd997a-e852-4e56-9f65-14b60261faee]
 description = "ability modifier for score 18 is +4"
-include = true
 
 [4f28f19c-2e47-4453-a46a-c0d365259c14]
 description = "random ability is within range"
-include = true
 
 [385d7e72-864f-4e88-8279-81a7d75b04ad]
 description = "random character is valid"
-include = true
 
 [2ca77b9b-c099-46c3-a02c-0d0f68ffa0fe]
 description = "each ability is only calculated once"
-include = true

--- a/exercises/practice/dominoes/.meta/tests.toml
+++ b/exercises/practice/dominoes/.meta/tests.toml
@@ -4,48 +4,36 @@
 
 [31a673f2-5e54-49fe-bd79-1c1dae476c9c]
 description = "empty input = empty output"
-include = true
 
 [4f99b933-367b-404b-8c6d-36d5923ee476]
 description = "singleton input = singleton output"
-include = true
 
 [91122d10-5ec7-47cb-b759-033756375869]
 description = "singleton that can't be chained"
-include = true
 
 [be8bc26b-fd3d-440b-8e9f-d698a0623be3]
 description = "three elements"
-include = true
 
 [99e615c6-c059-401c-9e87-ad7af11fea5c]
 description = "can reverse dominoes"
-include = true
 
 [51f0c291-5d43-40c5-b316-0429069528c9]
 description = "can't be chained"
-include = true
 
 [9a75e078-a025-4c23-8c3a-238553657f39]
 description = "disconnected - simple"
-include = true
 
 [0da0c7fe-d492-445d-b9ef-1f111f07a301]
 description = "disconnected - double loop"
-include = true
 
 [b6087ff0-f555-4ea0-a71c-f9d707c5994a]
 description = "disconnected - single isolated"
-include = true
 
 [2174fbdc-8b48-4bac-9914-8090d06ef978]
 description = "need backtrack"
-include = true
 
 [167bb480-dfd1-4318-a20d-4f90adb4a09f]
 description = "separate loops"
-include = true
 
 [cd061538-6046-45a7-ace9-6708fe8f6504]
 description = "nine elements"
-include = true

--- a/exercises/practice/etl/.meta/tests.toml
+++ b/exercises/practice/etl/.meta/tests.toml
@@ -4,16 +4,12 @@
 
 [78a7a9f9-4490-4a47-8ee9-5a38bb47d28f]
 description = "single letter"
-include = true
 
 [60dbd000-451d-44c7-bdbb-97c73ac1f497]
 description = "single score with multiple letters"
-include = true
 
 [f5c5de0c-301f-4fdd-a0e5-df97d4214f54]
 description = "multiple scores with multiple letters"
-include = true
 
 [5db8ea89-ecb4-4dcd-902f-2b418cc87b9d]
 description = "multiple scores with differing numbers of letters"
-include = true

--- a/exercises/practice/flatten-array/.meta/tests.toml
+++ b/exercises/practice/flatten-array/.meta/tests.toml
@@ -4,24 +4,18 @@
 
 [d268b919-963c-442d-9f07-82b93f1b518c]
 description = "no nesting"
-include = true
 
 [c84440cc-bb3a-48a6-862c-94cf23f2815d]
 description = "flattens array with just integers present"
-include = true
 
 [d3d99d39-6be5-44f5-a31d-6037d92ba34f]
 description = "5 level nesting"
-include = true
 
 [d572bdba-c127-43ed-bdcd-6222ac83d9f7]
 description = "6 level nesting"
-include = true
 
 [ef1d4790-1b1e-4939-a179-51ace0829dbd]
 description = "6 level nest list with null values"
-include = true
 
 [85721643-705a-4150-93ab-7ae398e2942d]
 description = "all values in nested list are null"
-include = true

--- a/exercises/practice/food-chain/.meta/tests.toml
+++ b/exercises/practice/food-chain/.meta/tests.toml
@@ -4,40 +4,30 @@
 
 [751dce68-9412-496e-b6e8-855998c56166]
 description = "fly"
-include = true
 
 [6c56f861-0c5e-4907-9a9d-b2efae389379]
 description = "spider"
-include = true
 
 [3edf5f33-bef1-4e39-ae67-ca5eb79203fa]
 description = "bird"
-include = true
 
 [e866a758-e1ff-400e-9f35-f27f28cc288f]
 description = "cat"
-include = true
 
 [3f02c30e-496b-4b2a-8491-bc7e2953cafb]
 description = "dog"
-include = true
 
 [4b3fd221-01ea-46e0-825b-5734634fbc59]
 description = "goat"
-include = true
 
 [1b707da9-7001-4fac-941f-22ad9c7a65d4]
 description = "cow"
-include = true
 
 [3cb10d46-ae4e-4d2c-9296-83c9ffc04cdc]
 description = "horse"
-include = true
 
 [22b863d5-17e4-4d1e-93e4-617329a5c050]
 description = "multiple verses"
-include = true
 
 [e626b32b-745c-4101-bcbd-3b13456893db]
 description = "full song"
-include = true

--- a/exercises/practice/forth/.meta/tests.toml
+++ b/exercises/practice/forth/.meta/tests.toml
@@ -4,184 +4,138 @@
 
 [9962203f-f00a-4a85-b404-8a8ecbcec09d]
 description = "numbers just get pushed onto the stack"
-include = true
 
 [9e69588e-a3d8-41a3-a371-ea02206c1e6e]
 description = "can add two numbers"
-include = true
 
 [52336dd3-30da-4e5c-8523-bdf9a3427657]
 description = "errors if there is nothing on the stack"
-include = true
 
 [06efb9a4-817a-435e-b509-06166993c1b8]
 description = "errors if there is only one value on the stack"
-include = true
 
 [09687c99-7bbc-44af-8526-e402f997ccbf]
 description = "can subtract two numbers"
-include = true
 
 [5d63eee2-1f7d-4538-b475-e27682ab8032]
 description = "errors if there is nothing on the stack"
-include = true
 
 [b3cee1b2-9159-418a-b00d-a1bb3765c23b]
 description = "errors if there is only one value on the stack"
-include = true
 
 [5df0ceb5-922e-401f-974d-8287427dbf21]
 description = "can multiply two numbers"
-include = true
 
 [9e004339-15ac-4063-8ec1-5720f4e75046]
 description = "errors if there is nothing on the stack"
-include = true
 
 [8ba4b432-9f94-41e0-8fae-3b3712bd51b3]
 description = "errors if there is only one value on the stack"
-include = true
 
 [e74c2204-b057-4cff-9aa9-31c7c97a93f5]
 description = "can divide two numbers"
-include = true
 
 [54f6711c-4b14-4bb0-98ad-d974a22c4620]
 description = "performs integer division"
-include = true
 
 [a5df3219-29b4-4d2f-b427-81f82f42a3f1]
 description = "errors if dividing by zero"
-include = true
 
 [1d5bb6b3-6749-4e02-8a79-b5d4d334cb8a]
 description = "errors if there is nothing on the stack"
-include = true
 
 [d5547f43-c2ff-4d5c-9cb0-2a4f6684c20d]
 description = "errors if there is only one value on the stack"
-include = true
 
 [ee28d729-6692-4a30-b9be-0d830c52a68c]
 description = "addition and subtraction"
-include = true
 
 [40b197da-fa4b-4aca-a50b-f000d19422c1]
 description = "multiplication and division"
-include = true
 
 [c5758235-6eef-4bf6-ab62-c878e50b9957]
 description = "copies a value on the stack"
-include = true
 
 [f6889006-5a40-41e7-beb3-43b09e5a22f4]
 description = "copies the top value on the stack"
-include = true
 
 [40b7569c-8401-4bd4-a30d-9adf70d11bc4]
 description = "errors if there is nothing on the stack"
-include = true
 
 [1971da68-1df2-4569-927a-72bf5bb7263c]
 description = "removes the top value on the stack if it is the only one"
-include = true
 
 [8929d9f2-4a78-4e0f-90ad-be1a0f313fd9]
 description = "removes the top value on the stack if it is not the only one"
-include = true
 
 [6dd31873-6dd7-4cb8-9e90-7daa33ba045c]
 description = "errors if there is nothing on the stack"
-include = true
 
 [3ee68e62-f98a-4cce-9e6c-8aae6c65a4e3]
 description = "swaps the top two values on the stack if they are the only ones"
-include = true
 
 [8ce869d5-a503-44e4-ab55-1da36816ff1c]
 description = "swaps the top two values on the stack if they are not the only ones"
-include = true
 
 [74ba5b2a-b028-4759-9176-c5c0e7b2b154]
 description = "errors if there is nothing on the stack"
-include = true
 
 [dd52e154-5d0d-4a5c-9e5d-73eb36052bc8]
 description = "errors if there is only one value on the stack"
-include = true
 
 [a2654074-ba68-4f93-b014-6b12693a8b50]
 description = "copies the second element if there are only two"
-include = true
 
 [c5b51097-741a-4da7-8736-5c93fa856339]
 description = "copies the second element if there are more than two"
-include = true
 
 [6e1703a6-5963-4a03-abba-02e77e3181fd]
 description = "errors if there is nothing on the stack"
-include = true
 
 [ee574dc4-ef71-46f6-8c6a-b4af3a10c45f]
 description = "errors if there is only one value on the stack"
-include = true
 
 [ed45cbbf-4dbf-4901-825b-54b20dbee53b]
 description = "can consist of built-in words"
-include = true
 
 [2726ea44-73e4-436b-bc2b-5ff0c6aa014b]
 description = "execute in the right order"
-include = true
 
 [9e53c2d0-b8ef-4ad8-b2c9-a559b421eb33]
 description = "can override other user-defined words"
-include = true
 
 [669db3f3-5bd6-4be0-83d1-618cd6e4984b]
 description = "can override built-in words"
-include = true
 
 [588de2f0-c56e-4c68-be0b-0bb1e603c500]
 description = "can override built-in operators"
-include = true
 
 [ac12aaaf-26c6-4a10-8b3c-1c958fa2914c]
 description = "can use different words with the same name"
-include = true
 
 [53f82ef0-2750-4ccb-ac04-5d8c1aefabb1]
 description = "can define word that uses word with the same name"
-include = true
 
 [35958cee-a976-4a0f-9378-f678518fa322]
 description = "cannot redefine numbers"
-include = true
 
 [5180f261-89dd-491e-b230-62737e09806f]
 description = "errors if executing a non-existent word"
-include = true
 
 [7b83bb2e-b0e8-461f-ad3b-96ee2e111ed6]
 description = "DUP is case-insensitive"
-include = true
 
 [339ed30b-f5b4-47ff-ab1c-67591a9cd336]
 description = "DROP is case-insensitive"
-include = true
 
 [ee1af31e-1355-4b1b-bb95-f9d0b2961b87]
 description = "SWAP is case-insensitive"
-include = true
 
 [acdc3a49-14c8-4cc2-945d-11edee6408fa]
 description = "OVER is case-insensitive"
-include = true
 
 [5934454f-a24f-4efc-9fdd-5794e5f0c23c]
 description = "user-defined words are case-insensitive"
-include = true
 
 [037d4299-195f-4be7-a46d-f07ca6280a06]
 description = "definitions are case-insensitive"
-include = true

--- a/exercises/practice/gigasecond/.meta/tests.toml
+++ b/exercises/practice/gigasecond/.meta/tests.toml
@@ -4,20 +4,15 @@
 
 [92fbe71c-ea52-4fac-bd77-be38023cacf7]
 description = "date only specification of time"
-include = true
 
 [6d86dd16-6f7a-47be-9e58-bb9fb2ae1433]
 description = "second test for date only specification of time"
-include = true
 
 [77eb8502-2bca-4d92-89d9-7b39ace28dd5]
 description = "third test for date only specification of time"
-include = true
 
 [c9d89a7d-06f8-4e28-a305-64f1b2abc693]
 description = "full time specified"
-include = true
 
 [09d4e30e-728a-4b52-9005-be44a58d9eba]
 description = "full time with day roll-over"
-include = true

--- a/exercises/practice/go-counting/.meta/tests.toml
+++ b/exercises/practice/go-counting/.meta/tests.toml
@@ -4,44 +4,33 @@
 
 [94d0c01a-17d0-424c-aab5-2736d0da3939]
 description = "Black corner territory on 5x5 board"
-include = true
 
 [b33bec54-356a-485c-9c71-1142a9403213]
 description = "White center territory on 5x5 board"
-include = true
 
 [def7d124-422e-44ae-90e5-ceda09399bda]
 description = "Open corner territory on 5x5 board"
-include = true
 
 [57d79036-2618-47f4-aa87-56c06d362e3d]
 description = "A stone and not a territory on 5x5 board"
-include = true
 
 [0c84f852-e032-4762-9010-99f6a001da96]
 description = "Invalid because X is too low for 5x5 board"
-include = true
 
 [6f867945-9b2c-4bdd-b23e-b55fe2069a68]
 description = "Invalid because X is too high for 5x5 board"
-include = true
 
 [d67aaffd-fdf1-4e7f-b9e9-79897402b64a]
 description = "Invalid because Y is too low for 5x5 board"
-include = true
 
 [14f23c25-799e-4371-b3e5-777a2c30357a]
 description = "Invalid because Y is too high for 5x5 board"
-include = true
 
 [37fb04b5-98c1-4b96-8c16-af2d13624afd]
 description = "One territory is the whole board"
-include = true
 
 [9a1c59b7-234b-495a-8d60-638489f0fc0a]
 description = "Two territory rectangular board"
-include = true
 
 [d1645953-1cd5-4221-af6f-8164f96249e1]
 description = "Two region rectangular board"
-include = true

--- a/exercises/practice/grade-school/.meta/tests.toml
+++ b/exercises/practice/grade-school/.meta/tests.toml
@@ -4,32 +4,24 @@
 
 [6d0a30e4-1b4e-472e-8e20-c41702125667]
 description = "Adding a student adds them to the sorted roster"
-include = true
 
 [c125dab7-2a53-492f-a99a-56ad511940d8]
 description = "A student can't be in two different grades"
-include = true
 
 [233be705-dd58-4968-889d-fb3c7954c9cc]
 description = "Adding more students adds them to the sorted roster"
-include = true
 
 [75a51579-d1d7-407c-a2f8-2166e984e8ab]
 description = "Adding students to different grades adds them to the same sorted roster"
-include = true
 
 [a3f0fb58-f240-4723-8ddc-e644666b85cc]
 description = "Roster returns an empty list if there are no students enrolled"
-include = true
 
 [180a8ff9-5b94-43fc-9db1-d46b4a8c93b6]
 description = "Student names with grades are displayed in the same sorted roster"
-include = true
 
 [1bfbcef1-e4a3-49e8-8d22-f6f9f386187e]
 description = "Grade returns the students in that grade in alphabetical order"
-include = true
 
 [5e67aa3c-a3c6-4407-a183-d8fe59cd1630]
 description = "Grade returns an empty list if there are no students in that grade"
-include = true

--- a/exercises/practice/grains/.meta/tests.toml
+++ b/exercises/practice/grains/.meta/tests.toml
@@ -4,44 +4,33 @@
 
 [9fbde8de-36b2-49de-baf2-cd42d6f28405]
 description = "1"
-include = true
 
 [ee1f30c2-01d8-4298-b25d-c677331b5e6d]
 description = "2"
-include = true
 
 [10f45584-2fc3-4875-8ec6-666065d1163b]
 description = "3"
-include = true
 
 [a7cbe01b-36f4-4601-b053-c5f6ae055170]
 description = "4"
-include = true
 
 [c50acc89-8535-44e4-918f-b848ad2817d4]
 description = "16"
-include = true
 
 [acd81b46-c2ad-4951-b848-80d15ed5a04f]
 description = "32"
-include = true
 
 [c73b470a-5efb-4d53-9ac6-c5f6487f227b]
 description = "64"
-include = true
 
 [1d47d832-3e85-4974-9466-5bd35af484e3]
 description = "square 0 raises an exception"
-include = true
 
 [61974483-eeb2-465e-be54-ca5dde366453]
 description = "negative square raises an exception"
-include = true
 
 [a95e4374-f32c-45a7-a10d-ffec475c012f]
 description = "square greater than 64 raises an exception"
-include = true
 
 [6eb07385-3659-4b45-a6be-9dc474222750]
 description = "returns the total number of grains on the board"
-include = true

--- a/exercises/practice/grep/.meta/tests.toml
+++ b/exercises/practice/grep/.meta/tests.toml
@@ -4,100 +4,75 @@
 
 [9049fdfd-53a7-4480-a390-375203837d09]
 description = "One file, one match, no flags"
-include = true
 
 [76519cce-98e3-46cd-b287-aac31b1d77d6]
 description = "One file, one match, print line numbers flag"
-include = true
 
 [af0b6d3c-e0e8-475e-a112-c0fc10a1eb30]
 description = "One file, one match, case-insensitive flag"
-include = true
 
 [ff7af839-d1b8-4856-a53e-99283579b672]
 description = "One file, one match, print file names flag"
-include = true
 
 [8625238a-720c-4a16-81f2-924ec8e222cb]
 description = "One file, one match, match entire lines flag"
-include = true
 
 [2a6266b3-a60f-475c-a5f5-f5008a717d3e]
 description = "One file, one match, multiple flags"
-include = true
 
 [842222da-32e8-4646-89df-0d38220f77a1]
 description = "One file, several matches, no flags"
-include = true
 
 [4d84f45f-a1d8-4c2e-a00e-0b292233828c]
 description = "One file, several matches, print line numbers flag"
-include = true
 
 [0a483b66-315b-45f5-bc85-3ce353a22539]
 description = "One file, several matches, match entire lines flag"
-include = true
 
 [3d2ca86a-edd7-494c-8938-8eeed1c61cfa]
 description = "One file, several matches, case-insensitive flag"
-include = true
 
 [1f52001f-f224-4521-9456-11120cad4432]
 description = "One file, several matches, inverted flag"
-include = true
 
 [7a6ede7f-7dd5-4364-8bf8-0697c53a09fe]
 description = "One file, no matches, various flags"
-include = true
 
 [3d3dfc23-8f2a-4e34-abd6-7b7d140291dc]
 description = "One file, one match, file flag takes precedence over line flag"
-include = true
 
 [87b21b24-b788-4d6e-a68b-7afe9ca141fe]
 description = "One file, several matches, inverted and match entire lines flags"
-include = true
 
 [ba496a23-6149-41c6-a027-28064ed533e5]
 description = "Multiple files, one match, no flags"
-include = true
 
 [4539bd36-6daa-4bc3-8e45-051f69f5aa95]
 description = "Multiple files, several matches, no flags"
-include = true
 
 [9fb4cc67-78e2-4761-8e6b-a4b57aba1938]
 description = "Multiple files, several matches, print line numbers flag"
-include = true
 
 [aeee1ef3-93c7-4cd5-af10-876f8c9ccc73]
 description = "Multiple files, one match, print file names flag"
-include = true
 
 [d69f3606-7d15-4ddf-89ae-01df198e6b6c]
 description = "Multiple files, several matches, case-insensitive flag"
-include = true
 
 [82ef739d-6701-4086-b911-007d1a3deb21]
 description = "Multiple files, several matches, inverted flag"
-include = true
 
 [77b2eb07-2921-4ea0-8971-7636b44f5d29]
 description = "Multiple files, one match, match entire lines flag"
-include = true
 
 [e53a2842-55bb-4078-9bb5-04ac38929989]
 description = "Multiple files, one match, multiple flags"
-include = true
 
 [9c4f7f9a-a555-4e32-bb06-4b8f8869b2cb]
 description = "Multiple files, no matches, various flags"
-include = true
 
 [ba5a540d-bffd-481b-bd0c-d9a30f225e01]
 description = "Multiple files, several matches, file flag takes precedence over line number flag"
-include = true
 
 [ff406330-2f0b-4b17-9ee4-4b71c31dd6d2]
 description = "Multiple files, several matches, inverted and match entire lines flags"
-include = true

--- a/exercises/practice/hamming/.meta/tests.toml
+++ b/exercises/practice/hamming/.meta/tests.toml
@@ -4,23 +4,18 @@
 
 [f6dcb64f-03b0-4b60-81b1-3c9dbf47e887]
 description = "empty strands"
-include = true
 
 [54681314-eee2-439a-9db0-b0636c656156]
 description = "single letter identical strands"
-include = true
 
 [294479a3-a4c8-478f-8d63-6209815a827b]
 description = "single letter different strands"
-include = true
 
 [9aed5f34-5693-4344-9b31-40c692fb5592]
 description = "long identical strands"
-include = true
 
 [cd2273a5-c576-46c8-a52b-dee251c3e6e5]
 description = "long different strands"
-include = true
 
 [919f8ef0-b767-4d1b-8516-6379d07fcb28]
 description = "disallow first strand longer"
@@ -28,7 +23,6 @@ include = false
 
 [b9228bb1-465f-4141-b40f-1f99812de5a8]
 description = "disallow first strand longer"
-include = true
 
 [8a2d4ed0-ead5-4fdd-924d-27c4cf56e60e]
 description = "disallow second strand longer"
@@ -36,7 +30,6 @@ include = false
 
 [dab38838-26bb-4fff-acbe-3b0a9bfeba2d]
 description = "disallow second strand longer"
-include = true
 
 [5dce058b-28d4-4ca7-aa64-adfe4e17784c]
 description = "disallow left empty strand"
@@ -48,7 +41,6 @@ include = false
 
 [b764d47c-83ff-4de2-ab10-6cfe4b15c0f3]
 description = "disallow empty first strand"
-include = true
 
 [38826d4b-16fb-4639-ac3e-ba027dec8b5f]
 description = "disallow right empty strand"
@@ -60,4 +52,3 @@ include = false
 
 [9ab9262f-3521-4191-81f5-0ed184a5aa89]
 description = "disallow empty second strand"
-include = true

--- a/exercises/practice/hello-world/.meta/tests.toml
+++ b/exercises/practice/hello-world/.meta/tests.toml
@@ -4,4 +4,3 @@
 
 [af9ffe10-dc13-42d8-a742-e7bdafac449d]
 description = "Say Hi!"
-include = true

--- a/exercises/practice/high-scores/.meta/tests.toml
+++ b/exercises/practice/high-scores/.meta/tests.toml
@@ -4,40 +4,30 @@
 
 [1035eb93-2208-4c22-bab8-fef06769a73c]
 description = "List of scores"
-include = true
 
 [6aa5dbf5-78fa-4375-b22c-ffaa989732d2]
 description = "Latest score"
-include = true
 
 [b661a2e1-aebf-4f50-9139-0fb817dd12c6]
 description = "Personal best"
-include = true
 
 [3d996a97-c81c-4642-9afc-80b80dc14015]
 description = "Personal top three from a list of scores"
-include = true
 
 [1084ecb5-3eb4-46fe-a816-e40331a4e83a]
 description = "Personal top highest to lowest"
-include = true
 
 [e6465b6b-5a11-4936-bfe3-35241c4f4f16]
 description = "Personal top when there is a tie"
-include = true
 
 [f73b02af-c8fd-41c9-91b9-c86eaa86bce2]
 description = "Personal top when there are less than 3"
-include = true
 
 [16608eae-f60f-4a88-800e-aabce5df2865]
 description = "Personal top when there is only one"
-include = true
 
 [2df075f9-fec9-4756-8f40-98c52a11504f]
 description = "Latest score after personal top scores"
-include = true
 
 [809c4058-7eb1-4206-b01e-79238b9b71bc]
 description = "Scores after personal top scores"
-include = true

--- a/exercises/practice/house/.meta/tests.toml
+++ b/exercises/practice/house/.meta/tests.toml
@@ -4,56 +4,42 @@
 
 [28a540ff-f765-4348-9d57-ae33f25f41f2]
 description = "verse one - the house that jack built"
-include = true
 
 [ebc825ac-6e2b-4a5e-9afd-95732191c8da]
 description = "verse two - the malt that lay"
-include = true
 
 [1ed8bb0f-edb8-4bd1-b6d4-b64754fe4a60]
 description = "verse three - the rat that ate"
-include = true
 
 [64b0954e-8b7d-4d14-aad0-d3f6ce297a30]
 description = "verse four - the cat that killed"
-include = true
 
 [1e8d56bc-fe31-424d-9084-61e6111d2c82]
 description = "verse five - the dog that worried"
-include = true
 
 [6312dc6f-ab0a-40c9-8a55-8d4e582beac4]
 description = "verse six - the cow with the crumpled horn"
-include = true
 
 [68f76d18-6e19-4692-819c-5ff6a7f92feb]
 description = "verse seven - the maiden all forlorn"
-include = true
 
 [73872564-2004-4071-b51d-2e4326096747]
 description = "verse eight - the man all tattered and torn"
-include = true
 
 [0d53d743-66cb-4351-a173-82702f3338c9]
 description = "verse nine - the priest all shaven and shorn"
-include = true
 
 [452f24dc-8fd7-4a82-be1a-3b4839cfeb41]
 description = "verse 10 - the rooster that crowed in the morn"
-include = true
 
 [97176f20-2dd3-4646-ac72-cffced91ea26]
 description = "verse 11 - the farmer sowing his corn"
-include = true
 
 [09824c29-6aad-4dcd-ac98-f61374a6a8b7]
 description = "verse 12 - the horse and the hound and the horn"
-include = true
 
 [d2b980d3-7851-49e1-97ab-1524515ec200]
 description = "multiple verses"
-include = true
 
 [0311d1d0-e085-4f23-8ae7-92406fb3e803]
 description = "full rhyme"
-include = true

--- a/exercises/practice/isbn-verifier/.meta/tests.toml
+++ b/exercises/practice/isbn-verifier/.meta/tests.toml
@@ -4,68 +4,51 @@
 
 [0caa3eac-d2e3-4c29-8df8-b188bc8c9292]
 description = "valid isbn number"
-include = true
 
 [19f76b53-7c24-45f8-87b8-4604d0ccd248]
 description = "invalid isbn check digit"
-include = true
 
 [4164bfee-fb0a-4a1c-9f70-64c6a1903dcd]
 description = "valid isbn number with a check digit of 10"
-include = true
 
 [3ed50db1-8982-4423-a993-93174a20825c]
 description = "check digit is a character other than X"
-include = true
 
 [c19ba0c4-014f-4dc3-a63f-ff9aefc9b5ec]
 description = "invalid character in isbn"
-include = true
 
 [28025280-2c39-4092-9719-f3234b89c627]
 description = "X is only valid as a check digit"
-include = true
 
 [f6294e61-7e79-46b3-977b-f48789a4945b]
 description = "valid isbn without separating dashes"
-include = true
 
 [185ab99b-3a1b-45f3-aeec-b80d80b07f0b]
 description = "isbn without separating dashes and X as check digit"
-include = true
 
 [7725a837-ec8e-4528-a92a-d981dd8cf3e2]
 description = "isbn without check digit and dashes"
-include = true
 
 [47e4dfba-9c20-46ed-9958-4d3190630bdf]
 description = "too long isbn and no dashes"
-include = true
 
 [737f4e91-cbba-4175-95bf-ae630b41fb60]
 description = "too short isbn"
-include = true
 
 [5458a128-a9b6-4ff8-8afb-674e74567cef]
 description = "isbn without check digit"
-include = true
 
 [70b6ad83-d0a2-4ca7-a4d5-a9ab731800f7]
 description = "check digit of X should not be used for 0"
-include = true
 
 [94610459-55ab-4c35-9b93-ff6ea1a8e562]
 description = "empty isbn"
-include = true
 
 [7bff28d4-d770-48cc-80d6-b20b3a0fb46c]
 description = "input is 9 characters"
-include = true
 
 [ed6e8d1b-382c-4081-8326-8b772c581fec]
 description = "invalid characters are not ignored"
-include = true
 
 [fb5e48d8-7c03-4bfb-a088-b101df16fdc3]
 description = "input is too long but contains a valid isbn"
-include = true

--- a/exercises/practice/isogram/.meta/tests.toml
+++ b/exercises/practice/isogram/.meta/tests.toml
@@ -4,52 +4,39 @@
 
 [a0e97d2d-669e-47c7-8134-518a1e2c4555]
 description = "empty string"
-include = true
 
 [9a001b50-f194-4143-bc29-2af5ec1ef652]
 description = "isogram with only lower case characters"
-include = true
 
 [8ddb0ca3-276e-4f8b-89da-d95d5bae78a4]
 description = "word with one duplicated character"
-include = true
 
 [6450b333-cbc2-4b24-a723-0b459b34fe18]
 description = "word with one duplicated character from the end of the alphabet"
-include = true
 
 [a15ff557-dd04-4764-99e7-02cc1a385863]
 description = "longest reported english isogram"
-include = true
 
 [f1a7f6c7-a42f-4915-91d7-35b2ea11c92e]
 description = "word with duplicated character in mixed case"
-include = true
 
 [14a4f3c1-3b47-4695-b645-53d328298942]
 description = "word with duplicated character in mixed case, lowercase first"
-include = true
 
 [423b850c-7090-4a8a-b057-97f1cadd7c42]
 description = "hypothetical isogrammic word with hyphen"
-include = true
 
 [93dbeaa0-3c5a-45c2-8b25-428b8eacd4f2]
 description = "hypothetical word with duplicated character following hyphen"
-include = true
 
 [36b30e5c-173f-49c6-a515-93a3e825553f]
 description = "isogram with duplicated hyphen"
-include = true
 
 [cdabafa0-c9f4-4c1f-b142-689c6ee17d93]
 description = "made-up name that is an isogram"
-include = true
 
 [5fc61048-d74e-48fd-bc34-abfc21552d4d]
 description = "duplicated character in the middle"
-include = true
 
 [310ac53d-8932-47bc-bbb4-b2b94f25a83e]
 description = "same first and last characters"
-include = true

--- a/exercises/practice/kindergarten-garden/.meta/tests.toml
+++ b/exercises/practice/kindergarten-garden/.meta/tests.toml
@@ -4,68 +4,51 @@
 
 [1fc316ed-17ab-4fba-88ef-3ae78296b692]
 description = "garden with single student"
-include = true
 
 [acd19dc1-2200-4317-bc2a-08f021276b40]
 description = "different garden with single student"
-include = true
 
 [c376fcc8-349c-446c-94b0-903947315757]
 description = "garden with two students"
-include = true
 
 [2d620f45-9617-4924-9d27-751c80d17db9]
 description = "second student's garden"
-include = true
 
 [57712331-4896-4364-89f8-576421d69c44]
 description = "third student's garden"
-include = true
 
 [149b4290-58e1-40f2-8ae4-8b87c46e765b]
 description = "for Alice, first student's garden"
-include = true
 
 [ba25dbbc-10bd-4a37-b18e-f89ecd098a5e]
 description = "for Bob, second student's garden"
-include = true
 
 [566b621b-f18e-4c5f-873e-be30544b838c]
 description = "for Charlie"
-include = true
 
 [3ad3df57-dd98-46fc-9269-1877abf612aa]
 description = "for David"
-include = true
 
 [0f0a55d1-9710-46ed-a0eb-399ba8c72db2]
 description = "for Eve"
-include = true
 
 [a7e80c90-b140-4ea1-aee3-f4625365c9a4]
 description = "for Fred"
-include = true
 
 [9d94b273-2933-471b-86e8-dba68694c615]
 description = "for Ginny"
-include = true
 
 [f55bc6c2-ade8-4844-87c4-87196f1b7258]
 description = "for Harriet"
-include = true
 
 [759070a3-1bb1-4dd4-be2c-7cce1d7679ae]
 description = "for Ileana"
-include = true
 
 [78578123-2755-4d4a-9c7d-e985b8dda1c6]
 description = "for Joseph"
-include = true
 
 [6bb66df7-f433-41ab-aec2-3ead6e99f65b]
 description = "for Kincaid, second to last student's garden"
-include = true
 
 [d7edec11-6488-418a-94e6-ed509e0fa7eb]
 description = "for Larry, last student's garden"
-include = true

--- a/exercises/practice/knapsack/.meta/tests.toml
+++ b/exercises/practice/knapsack/.meta/tests.toml
@@ -4,28 +4,21 @@
 
 [a4d7d2f0-ad8a-460c-86f3-88ba709d41a7]
 description = "no items"
-include = true
 
 [1d39e98c-6249-4a8b-912f-87cb12e506b0]
 description = "one item, too heavy"
-include = true
 
 [833ea310-6323-44f2-9d27-a278740ffbd8]
 description = "five items (cannot be greedy by weight)"
-include = true
 
 [277cdc52-f835-4c7d-872b-bff17bab2456]
 description = "five items (cannot be greedy by value)"
-include = true
 
 [81d8e679-442b-4f7a-8a59-7278083916c9]
 description = "example knapsack"
-include = true
 
 [f23a2449-d67c-4c26-bf3e-cde020f27ecc]
 description = "8 items"
-include = true
 
 [7c682ae9-c385-4241-a197-d2fa02c81a11]
 description = "15 items"
-include = true

--- a/exercises/practice/largest-series-product/.meta/tests.toml
+++ b/exercises/practice/largest-series-product/.meta/tests.toml
@@ -4,60 +4,45 @@
 
 [7c82f8b7-e347-48ee-8a22-f672323324d4]
 description = "finds the largest product if span equals length"
-include = true
 
 [88523f65-21ba-4458-a76a-b4aaf6e4cb5e]
 description = "can find the largest product of 2 with numbers in order"
-include = true
 
 [f1376b48-1157-419d-92c2-1d7e36a70b8a]
 description = "can find the largest product of 2"
-include = true
 
 [46356a67-7e02-489e-8fea-321c2fa7b4a4]
 description = "can find the largest product of 3 with numbers in order"
-include = true
 
 [a2dcb54b-2b8f-4993-92dd-5ce56dece64a]
 description = "can find the largest product of 3"
-include = true
 
 [673210a3-33cd-4708-940b-c482d7a88f9d]
 description = "can find the largest product of 5 with numbers in order"
-include = true
 
 [02acd5a6-3bbf-46df-8282-8b313a80a7c9]
 description = "can get the largest product of a big number"
-include = true
 
 [76dcc407-21e9-424c-a98e-609f269622b5]
 description = "reports zero if the only digits are zero"
-include = true
 
 [6ef0df9f-52d4-4a5d-b210-f6fae5f20e19]
 description = "reports zero if all spans include zero"
-include = true
 
 [5d81aaf7-4f67-4125-bf33-11493cc7eab7]
 description = "rejects span longer than string length"
-include = true
 
 [06bc8b90-0c51-4c54-ac22-3ec3893a079e]
 description = "reports 1 for empty string and empty product (0 span)"
-include = true
 
 [3ec0d92e-f2e2-4090-a380-70afee02f4c0]
 description = "reports 1 for nonempty string and empty product (0 span)"
-include = true
 
 [6d96c691-4374-4404-80ee-2ea8f3613dd4]
 description = "rejects empty string and nonzero span"
-include = true
 
 [7a38f2d6-3c35-45f6-8d6f-12e6e32d4d74]
 description = "rejects invalid character in digits"
-include = true
 
 [5fe3c0e5-a945-49f2-b584-f0814b4dd1ef]
 description = "rejects negative span"
-include = true

--- a/exercises/practice/leap/.meta/tests.toml
+++ b/exercises/practice/leap/.meta/tests.toml
@@ -4,36 +4,27 @@
 
 [6466b30d-519c-438e-935d-388224ab5223]
 description = "year not divisible by 4 in common year"
-include = true
 
 [ac227e82-ee82-4a09-9eb6-4f84331ffdb0]
 description = "year divisible by 2, not divisible by 4 in common year"
-include = true
 
 [4fe9b84c-8e65-489e-970b-856d60b8b78e]
 description = "year divisible by 4, not divisible by 100 in leap year"
-include = true
 
 [7fc6aed7-e63c-48f5-ae05-5fe182f60a5d]
 description = "year divisible by 4 and 5 is still a leap year"
-include = true
 
 [78a7848f-9667-4192-ae53-87b30c9a02dd]
 description = "year divisible by 100, not divisible by 400 in common year"
-include = true
 
 [9d70f938-537c-40a6-ba19-f50739ce8bac]
 description = "year divisible by 100 but not by 3 is still not a leap year"
-include = true
 
 [42ee56ad-d3e6-48f1-8e3f-c84078d916fc]
 description = "year divisible by 400 in leap year"
-include = true
 
 [57902c77-6fe9-40de-8302-587b5c27121e]
 description = "year divisible by 400 but not by 125 is still a leap year"
-include = true
 
 [c30331f6-f9f6-4881-ad38-8ca8c12520c1]
 description = "year divisible by 200, not divisible by 400 in common year"
-include = true

--- a/exercises/practice/linked-list/.meta/tests.toml
+++ b/exercises/practice/linked-list/.meta/tests.toml
@@ -4,76 +4,57 @@
 
 [7f7e3987-b954-41b8-8084-99beca08752c]
 description = "pop gets element from the list"
-include = true
 
 [c3f67e5d-cfa2-4c3e-a18f-7ce999c3c885]
 description = "push/pop respectively add/remove at the end of the list"
-include = true
 
 [00ea24ce-4f5c-4432-abb4-cc6e85462657]
 description = "shift gets an element from the list"
-include = true
 
 [37962ee0-3324-4a29-b588-5a4c861e6564]
 description = "shift gets first element from the list"
-include = true
 
 [30a3586b-e9dc-43fb-9a73-2770cec2c718]
 description = "unshift adds element at start of the list"
-include = true
 
 [042f71e4-a8a7-4cf0-8953-7e4f3a21c42d]
 description = "pop, push, shift, and unshift can be used in any order"
-include = true
 
 [88f65c0c-4532-4093-8295-2384fb2f37df]
 description = "count an empty list"
-include = true
 
 [fc055689-5cbe-4cd9-b994-02e2abbb40a5]
 description = "count a list with items"
-include = true
 
 [8272cef5-130d-40ea-b7f6-5ffd0790d650]
 description = "count is correct after mutation"
-include = true
 
 [229b8f7a-bd8a-4798-b64f-0dc0bb356d95]
 description = "popping to empty doesn't break the list"
-include = true
 
 [4e1948b4-514e-424b-a3cf-a1ebbfa2d1ad]
 description = "shifting to empty doesn't break the list"
-include = true
 
 [e8f7c600-d597-4f79-949d-8ad8bae895a6]
 description = "deletes the only element"
-include = true
 
 [fd65e422-51f3-45c0-9fd0-c33da638f89b]
 description = "deletes the element with the specified value from the list"
-include = true
 
 [59db191a-b17f-4ab7-9c5c-60711ec1d013]
 description = "deletes the element with the specified value from the list, re-assigns tail"
-include = true
 
 [58242222-5d39-415b-951d-8128247f8993]
 description = "deletes the element with the specified value from the list, re-assigns head"
-include = true
 
 [ee3729ee-3405-4bd2-9bad-de0d4aa5d647]
 description = "deletes the first of two elements"
-include = true
 
 [47e3b3b4-b82c-4c23-8c1a-ceb9b17cb9fb]
 description = "deletes the second of two elements"
-include = true
 
 [7b420958-f285-4922-b8f9-10d9dcab5179]
 description = "delete does not modify the list if the element is not found"
-include = true
 
 [7e04828f-6082-44e3-a059-201c63252a76]
 description = "deletes only the first occurrence"
-include = true

--- a/exercises/practice/list-ops/.meta/tests.toml
+++ b/exercises/practice/list-ops/.meta/tests.toml
@@ -4,55 +4,42 @@
 
 [485b9452-bf94-40f7-a3db-c3cf4850066a]
 description = "empty lists"
-include = true
 
 [2c894696-b609-4569-b149-8672134d340a]
 description = "list to empty list"
-include = true
 
 [e842efed-3bf6-4295-b371-4d67a4fdf19c]
 description = "empty list to list"
-include = true
 
 [71dcf5eb-73ae-4a0e-b744-a52ee387922f]
 description = "non-empty lists"
-include = true
 
 [28444355-201b-4af2-a2f6-5550227bde21]
 description = "empty list"
-include = true
 
 [331451c1-9573-42a1-9869-2d06e3b389a9]
 description = "list of lists"
-include = true
 
 [d6ecd72c-197f-40c3-89a4-aa1f45827e09]
 description = "list of nested lists"
-include = true
 
 [0524fba8-3e0f-4531-ad2b-f7a43da86a16]
 description = "empty list"
-include = true
 
 [88494bd5-f520-4edb-8631-88e415b62d24]
 description = "non-empty list"
-include = true
 
 [1cf0b92d-8d96-41d5-9c21-7b3c37cb6aad]
 description = "empty list"
-include = true
 
 [d7b8d2d9-2d16-44c4-9a19-6e5f237cb71e]
 description = "non-empty list"
-include = true
 
 [c0bc8962-30e2-4bec-9ae4-668b8ecd75aa]
 description = "empty list"
-include = true
 
 [11e71a95-e78b-4909-b8e4-60cdcaec0e91]
 description = "non-empty list"
-include = true
 
 [613b20b7-1873-4070-a3a6-70ae5f50d7cc]
 description = "empty list"
@@ -68,15 +55,12 @@ include = false
 
 [36549237-f765-4a4c-bfd9-5d3a8f7b07d2]
 description = "empty list"
-include = true
 
 [7a626a3c-03ec-42bc-9840-53f280e13067]
 description = "direction independent function applied to non-empty list"
-include = true
 
 [d7fcad99-e88e-40e1-a539-4c519681f390]
 description = "direction dependent function applied to non-empty list"
-include = true
 
 [aeb576b9-118e-4a57-a451-db49fac20fdc]
 description = "empty list"
@@ -92,24 +76,18 @@ include = false
 
 [17214edb-20ba-42fc-bda8-000a5ab525b0]
 description = "empty list"
-include = true
 
 [e1c64db7-9253-4a3d-a7c4-5273b9e2a1bd]
 description = "direction independent function applied to non-empty list"
-include = true
 
 [8066003b-f2ff-437e-9103-66e6df474844]
 description = "direction dependent function applied to non-empty list"
-include = true
 
 [94231515-050e-4841-943d-d4488ab4ee30]
 description = "empty list"
-include = true
 
 [fcc03d1e-42e0-4712-b689-d54ad761f360]
 description = "non-empty list"
-include = true
 
 [40872990-b5b8-4cb8-9085-d91fc0d05d26]
 description = "list of lists is not flattened"
-include = true

--- a/exercises/practice/luhn/.meta/tests.toml
+++ b/exercises/practice/luhn/.meta/tests.toml
@@ -4,72 +4,54 @@
 
 [792a7082-feb7-48c7-b88b-bbfec160865e]
 description = "single digit strings can not be valid"
-include = true
 
 [698a7924-64d4-4d89-8daa-32e1aadc271e]
 description = "a single zero is invalid"
-include = true
 
 [73c2f62b-9b10-4c9f-9a04-83cee7367965]
 description = "a simple valid SIN that remains valid if reversed"
-include = true
 
 [9369092e-b095-439f-948d-498bd076be11]
 description = "a simple valid SIN that becomes invalid if reversed"
-include = true
 
 [8f9f2350-1faf-4008-ba84-85cbb93ffeca]
 description = "a valid Canadian SIN"
-include = true
 
 [1cdcf269-6560-44fc-91f6-5819a7548737]
 description = "invalid Canadian SIN"
-include = true
 
 [656c48c1-34e8-4e60-9a5a-aad8a367810a]
 description = "invalid credit card"
-include = true
 
 [20e67fad-2121-43ed-99a8-14b5b856adb9]
 description = "invalid long number with an even remainder"
-include = true
 
 [ad2a0c5f-84ed-4e5b-95da-6011d6f4f0aa]
 description = "valid number with an even number of digits"
-include = true
 
 [ef081c06-a41f-4761-8492-385e13c8202d]
 description = "valid number with an odd number of spaces"
-include = true
 
 [bef66f64-6100-4cbb-8f94-4c9713c5e5b2]
 description = "valid strings with a non-digit added at the end become invalid"
-include = true
 
 [2177e225-9ce7-40f6-b55d-fa420e62938e]
 description = "valid strings with punctuation included become invalid"
-include = true
 
 [ebf04f27-9698-45e1-9afe-7e0851d0fe8d]
 description = "valid strings with symbols included become invalid"
-include = true
 
 [08195c5e-ce7f-422c-a5eb-3e45fece68ba]
 description = "single zero with space is invalid"
-include = true
 
 [12e63a3c-f866-4a79-8c14-b359fc386091]
 description = "more than a single zero is valid"
-include = true
 
 [ab56fa80-5de8-4735-8a4a-14dae588663e]
 description = "input digit 9 is correctly converted to output digit 9"
-include = true
 
 [39a06a5a-5bad-4e0f-b215-b042d46209b1]
 description = "using ascii value for non-doubled non-digit isn't allowed"
-include = true
 
 [f94cf191-a62f-4868-bc72-7253114aa157]
 description = "using ascii value for doubled non-digit isn't allowed"
-include = true

--- a/exercises/practice/markdown/.meta/tests.toml
+++ b/exercises/practice/markdown/.meta/tests.toml
@@ -4,52 +4,39 @@
 
 [e75c8103-a6b8-45d9-84ad-e68520545f6e]
 description = "parses normal text as a paragraph"
-include = true
 
 [69a4165d-9bf8-4dd7-bfdc-536eaca80a6a]
 description = "parsing italics"
-include = true
 
 [ec345a1d-db20-4569-a81a-172fe0cad8a1]
 description = "parsing bold text"
-include = true
 
 [51164ed4-5641-4909-8fab-fbaa9d37d5a8]
 description = "mixed normal, italics and bold text"
-include = true
 
 [ad85f60d-0edd-4c6a-a9b1-73e1c4790d15]
 description = "with h1 header level"
-include = true
 
 [d0f7a31f-6935-44ac-8a9a-1e8ab16af77f]
 description = "with h2 header level"
-include = true
 
 [13b5f410-33f5-44f0-a6a7-cfd4ab74b5d5]
 description = "with h6 header level"
-include = true
 
 [25288a2b-8edc-45db-84cf-0b6c6ee034d6]
 description = "unordered lists"
-include = true
 
 [7bf92413-df8f-4de8-9184-b724f363c3da]
 description = "With a little bit of everything"
-include = true
 
 [0b3ed1ec-3991-4b8b-8518-5cb73d4a64fe]
 description = "with markdown symbols in the header text that should not be interpreted"
-include = true
 
 [113a2e58-78de-4efa-90e9-20972224d759]
 description = "with markdown symbols in the list item text that should not be interpreted"
-include = true
 
 [e65e46e2-17b7-4216-b3ac-f44a1b9bcdb4]
 description = "with markdown symbols in the paragraph text that should not be interpreted"
-include = true
 
 [f0bbbbde-0f52-4c0c-99ec-be4c60126dd4]
 description = "unordered lists close properly with preceding and following lines"
-include = true

--- a/exercises/practice/matching-brackets/.meta/tests.toml
+++ b/exercises/practice/matching-brackets/.meta/tests.toml
@@ -4,68 +4,51 @@
 
 [81ec11da-38dd-442a-bcf9-3de7754609a5]
 description = "paired square brackets"
-include = true
 
 [287f0167-ac60-4b64-8452-a0aa8f4e5238]
 description = "empty string"
-include = true
 
 [6c3615a3-df01-4130-a731-8ef5f5d78dac]
 description = "unpaired brackets"
-include = true
 
 [9d414171-9b98-4cac-a4e5-941039a97a77]
 description = "wrong ordered brackets"
-include = true
 
 [f0f97c94-a149-4736-bc61-f2c5148ffb85]
 description = "wrong closing bracket"
-include = true
 
 [754468e0-4696-4582-a30e-534d47d69756]
 description = "paired with whitespace"
-include = true
 
 [ba84f6ee-8164-434a-9c3e-b02c7f8e8545]
 description = "partially paired brackets"
-include = true
 
 [3c86c897-5ff3-4a2b-ad9b-47ac3a30651d]
 description = "simple nested brackets"
-include = true
 
 [2d137f2c-a19e-4993-9830-83967a2d4726]
 description = "several paired brackets"
-include = true
 
 [2e1f7b56-c137-4c92-9781-958638885a44]
 description = "paired and nested brackets"
-include = true
 
 [84f6233b-e0f7-4077-8966-8085d295c19b]
 description = "unopened closing brackets"
-include = true
 
 [9b18c67d-7595-4982-b2c5-4cb949745d49]
 description = "unpaired and nested brackets"
-include = true
 
 [a0205e34-c2ac-49e6-a88a-899508d7d68e]
 description = "paired and wrong nested brackets"
-include = true
 
 [ef47c21b-bcfd-4998-844c-7ad5daad90a8]
 description = "paired and incomplete brackets"
-include = true
 
 [a4675a40-a8be-4fc2-bc47-2a282ce6edbe]
 description = "too many closing brackets"
-include = true
 
 [99255f93-261b-4435-a352-02bdecc9bdf2]
 description = "math expression"
-include = true
 
 [8e357d79-f302-469a-8515-2561877256a1]
 description = "complex latex expression"
-include = true

--- a/exercises/practice/matrix/.meta/tests.toml
+++ b/exercises/practice/matrix/.meta/tests.toml
@@ -4,32 +4,24 @@
 
 [ca733dab-9d85-4065-9ef6-a880a951dafd]
 description = "extract row from one number matrix"
-include = true
 
 [5c93ec93-80e1-4268-9fc2-63bc7d23385c]
 description = "can extract row"
-include = true
 
 [2f1aad89-ad0f-4bd2-9919-99a8bff0305a]
 description = "extract row where numbers have different widths"
-include = true
 
 [68f7f6ba-57e2-4e87-82d0-ad09889b5204]
 description = "can extract row from non-square matrix with no corresponding column"
-include = true
 
 [e8c74391-c93b-4aed-8bfe-f3c9beb89ebb]
 description = "extract column from one number matrix"
-include = true
 
 [7136bdbd-b3dc-48c4-a10c-8230976d3727]
 description = "can extract column"
-include = true
 
 [ad64f8d7-bba6-4182-8adf-0c14de3d0eca]
 description = "can extract column from non-square matrix with no corresponding row"
-include = true
 
 [9eddfa5c-8474-440e-ae0a-f018c2a0dd89]
 description = "extract column where numbers have different widths"
-include = true

--- a/exercises/practice/meetup/.meta/tests.toml
+++ b/exercises/practice/meetup/.meta/tests.toml
@@ -4,380 +4,285 @@
 
 [d7f8eadd-d4fc-46ee-8a20-e97bd3fd01c8]
 description = "monteenth of May 2013"
-include = true
 
 [f78373d1-cd53-4a7f-9d37-e15bf8a456b4]
 description = "monteenth of August 2013"
-include = true
 
 [8c78bea7-a116-425b-9c6b-c9898266d92a]
 description = "monteenth of September 2013"
-include = true
 
 [cfef881b-9dc9-4d0b-8de4-82d0f39fc271]
 description = "tuesteenth of March 2013"
-include = true
 
 [69048961-3b00-41f9-97ee-eb6d83a8e92b]
 description = "tuesteenth of April 2013"
-include = true
 
 [d30bade8-3622-466a-b7be-587414e0caa6]
 description = "tuesteenth of August 2013"
-include = true
 
 [8db4b58b-92f3-4687-867b-82ee1a04f851]
 description = "wednesteenth of January 2013"
-include = true
 
 [6c27a2a2-28f8-487f-ae81-35d08c4664f7]
 description = "wednesteenth of February 2013"
-include = true
 
 [008a8674-1958-45b5-b8e6-c2c9960d973a]
 description = "wednesteenth of June 2013"
-include = true
 
 [e4abd5e3-57cb-4091-8420-d97e955c0dbd]
 description = "thursteenth of May 2013"
-include = true
 
 [85da0b0f-eace-4297-a6dd-63588d5055b4]
 description = "thursteenth of June 2013"
-include = true
 
 [ecf64f9b-8413-489b-bf6e-128045f70bcc]
 description = "thursteenth of September 2013"
-include = true
 
 [ac4e180c-7d0a-4d3d-b05f-f564ebb584ca]
 description = "friteenth of April 2013"
-include = true
 
 [b79101c7-83ad-4f8f-8ec8-591683296315]
 description = "friteenth of August 2013"
-include = true
 
 [6ed38b9f-0072-4901-bd97-7c8b8b0ef1b8]
 description = "friteenth of September 2013"
-include = true
 
 [dfae03ed-9610-47de-a632-655ab01e1e7c]
 description = "saturteenth of February 2013"
-include = true
 
 [ec02e3e1-fc72-4a3c-872f-a53fa8ab358e]
 description = "saturteenth of April 2013"
-include = true
 
 [d983094b-7259-4195-b84e-5d09578c89d9]
 description = "saturteenth of October 2013"
-include = true
 
 [d84a2a2e-f745-443a-9368-30051be60c2e]
 description = "sunteenth of May 2013"
-include = true
 
 [0e64bc53-92a3-4f61-85b2-0b7168c7ce5a]
 description = "sunteenth of June 2013"
-include = true
 
 [de87652c-185e-4854-b3ae-04cf6150eead]
 description = "sunteenth of October 2013"
-include = true
 
 [2cbfd0f5-ba3a-46da-a8cc-0fe4966d3411]
 description = "first Monday of March 2013"
-include = true
 
 [a6168c7c-ed95-4bb3-8f92-c72575fc64b0]
 description = "first Monday of April 2013"
-include = true
 
 [1bfc620f-1c54-4bbd-931f-4a1cd1036c20]
 description = "first Tuesday of May 2013"
-include = true
 
 [12959c10-7362-4ca0-a048-50cf1c06e3e2]
 description = "first Tuesday of June 2013"
-include = true
 
 [1033dc66-8d0b-48a1-90cb-270703d59d1d]
 description = "first Wednesday of July 2013"
-include = true
 
 [b89185b9-2f32-46f4-a602-de20b09058f6]
 description = "first Wednesday of August 2013"
-include = true
 
 [53aedc4d-b2c8-4dfb-abf7-a8dc9cdceed5]
 description = "first Thursday of September 2013"
-include = true
 
 [b420a7e3-a94c-4226-870a-9eb3a92647f0]
 description = "first Thursday of October 2013"
-include = true
 
 [61df3270-28b4-4713-bee2-566fa27302ca]
 description = "first Friday of November 2013"
-include = true
 
 [cad33d4d-595c-412f-85cf-3874c6e07abf]
 description = "first Friday of December 2013"
-include = true
 
 [a2869b52-5bba-44f0-a863-07bd1f67eadb]
 description = "first Saturday of January 2013"
-include = true
 
 [3585315a-d0db-4ea1-822e-0f22e2a645f5]
 description = "first Saturday of February 2013"
-include = true
 
 [c49e9bd9-8ccf-4cf2-947a-0ccd4e4f10b1]
 description = "first Sunday of March 2013"
-include = true
 
 [1513328b-df53-4714-8677-df68c4f9366c]
 description = "first Sunday of April 2013"
-include = true
 
 [49e083af-47ec-4018-b807-62ef411efed7]
 description = "second Monday of March 2013"
-include = true
 
 [6cb79a73-38fe-4475-9101-9eec36cf79e5]
 description = "second Monday of April 2013"
-include = true
 
 [4c39b594-af7e-4445-aa03-bf4f8effd9a1]
 description = "second Tuesday of May 2013"
-include = true
 
 [41b32c34-2e39-40e3-b790-93539aaeb6dd]
 description = "second Tuesday of June 2013"
-include = true
 
 [90a160c5-b5d9-4831-927f-63a78b17843d]
 description = "second Wednesday of July 2013"
-include = true
 
 [23b98ce7-8dd5-41a1-9310-ef27209741cb]
 description = "second Wednesday of August 2013"
-include = true
 
 [447f1960-27ca-4729-bc3f-f36043f43ed0]
 description = "second Thursday of September 2013"
-include = true
 
 [c9aa2687-300c-4e79-86ca-077849a81bde]
 description = "second Thursday of October 2013"
-include = true
 
 [a7e11ef3-6625-4134-acda-3e7195421c09]
 description = "second Friday of November 2013"
-include = true
 
 [8b420e5f-9290-4106-b5ae-022f3e2a3e41]
 description = "second Friday of December 2013"
-include = true
 
 [80631afc-fc11-4546-8b5f-c12aaeb72b4f]
 description = "second Saturday of January 2013"
-include = true
 
 [e34d43ac-f470-44c2-aa5f-e97b78ecaf83]
 description = "second Saturday of February 2013"
-include = true
 
 [a57d59fd-1023-47ad-b0df-a6feb21b44fc]
 description = "second Sunday of March 2013"
-include = true
 
 [a829a8b0-abdd-4ad1-b66c-5560d843c91a]
 description = "second Sunday of April 2013"
-include = true
 
 [501a8a77-6038-4fc0-b74c-33634906c29d]
 description = "third Monday of March 2013"
-include = true
 
 [49e4516e-cf32-4a58-8bbc-494b7e851c92]
 description = "third Monday of April 2013"
-include = true
 
 [4db61095-f7c7-493c-85f1-9996ad3012c7]
 description = "third Tuesday of May 2013"
-include = true
 
 [714fc2e3-58d0-4b91-90fd-61eefd2892c0]
 description = "third Tuesday of June 2013"
-include = true
 
 [b08a051a-2c80-445b-9b0e-524171a166d1]
 description = "third Wednesday of July 2013"
-include = true
 
 [80bb9eff-3905-4c61-8dc9-bb03016d8ff8]
 description = "third Wednesday of August 2013"
-include = true
 
 [fa52a299-f77f-4784-b290-ba9189fbd9c9]
 description = "third Thursday of September 2013"
-include = true
 
 [f74b1bc6-cc5c-4bf1-ba69-c554a969eb38]
 description = "third Thursday of October 2013"
-include = true
 
 [8900f3b0-801a-466b-a866-f42d64667abd]
 description = "third Friday of November 2013"
-include = true
 
 [538ac405-a091-4314-9ccd-920c4e38e85e]
 description = "third Friday of December 2013"
-include = true
 
 [244db35c-2716-4fa0-88ce-afd58e5cf910]
 description = "third Saturday of January 2013"
-include = true
 
 [dd28544f-f8fa-4f06-9bcd-0ad46ce68e9e]
 description = "third Saturday of February 2013"
-include = true
 
 [be71dcc6-00d2-4b53-a369-cbfae55b312f]
 description = "third Sunday of March 2013"
-include = true
 
 [b7d2da84-4290-4ee6-a618-ee124ae78be7]
 description = "third Sunday of April 2013"
-include = true
 
 [4276dc06-a1bd-4fc2-b6c2-625fee90bc88]
 description = "fourth Monday of March 2013"
-include = true
 
 [ddbd7976-2deb-4250-8a38-925ac1a8e9a2]
 description = "fourth Monday of April 2013"
-include = true
 
 [eb714ef4-1656-47cc-913c-844dba4ebddd]
 description = "fourth Tuesday of May 2013"
-include = true
 
 [16648435-7937-4d2d-b118-c3e38fd084bd]
 description = "fourth Tuesday of June 2013"
-include = true
 
 [de062bdc-9484-437a-a8c5-5253c6f6785a]
 description = "fourth Wednesday of July 2013"
-include = true
 
 [c2ce6821-169c-4832-8d37-690ef5d9514a]
 description = "fourth Wednesday of August 2013"
-include = true
 
 [d462c631-2894-4391-a8e3-dbb98b7a7303]
 description = "fourth Thursday of September 2013"
-include = true
 
 [9ff1f7b6-1b72-427d-9ee9-82b5bb08b835]
 description = "fourth Thursday of October 2013"
-include = true
 
 [83bae8ba-1c49-49bc-b632-b7c7e1d7e35f]
 description = "fourth Friday of November 2013"
-include = true
 
 [de752d2a-a95e-48d2-835b-93363dac3710]
 description = "fourth Friday of December 2013"
-include = true
 
 [eedd90ad-d581-45db-8312-4c6dcf9cf560]
 description = "fourth Saturday of January 2013"
-include = true
 
 [669fedcd-912e-48c7-a0a1-228b34af91d0]
 description = "fourth Saturday of February 2013"
-include = true
 
 [648e3849-ea49-44a5-a8a3-9f2a43b3bf1b]
 description = "fourth Sunday of March 2013"
-include = true
 
 [f81321b3-99ab-4db6-9267-69c5da5a7823]
 description = "fourth Sunday of April 2013"
-include = true
 
 [1af5e51f-5488-4548-aee8-11d7d4a730dc]
 description = "last Monday of March 2013"
-include = true
 
 [f29999f2-235e-4ec7-9dab-26f137146526]
 description = "last Monday of April 2013"
-include = true
 
 [31b097a0-508e-48ac-bf8a-f63cdcf6dc41]
 description = "last Tuesday of May 2013"
-include = true
 
 [8c022150-0bb5-4a1f-80f9-88b2e2abcba4]
 description = "last Tuesday of June 2013"
-include = true
 
 [0e762194-672a-4bdf-8a37-1e59fdacef12]
 description = "last Wednesday of July 2013"
-include = true
 
 [5016386a-f24e-4bd7-b439-95358f491b66]
 description = "last Wednesday of August 2013"
-include = true
 
 [12ead1a5-cdf9-4192-9a56-2229e93dd149]
 description = "last Thursday of September 2013"
-include = true
 
 [7db89e11-7fbe-4e57-ae3c-0f327fbd7cc7]
 description = "last Thursday of October 2013"
-include = true
 
 [e47a739e-b979-460d-9c8a-75c35ca2290b]
 description = "last Friday of November 2013"
-include = true
 
 [5bed5aa9-a57a-4e5d-8997-2cc796a5b0ec]
 description = "last Friday of December 2013"
-include = true
 
 [61e54cba-76f3-4772-a2b1-bf443fda2137]
 description = "last Saturday of January 2013"
-include = true
 
 [8b6a737b-2fa9-444c-b1a2-80ce7a2ec72f]
 description = "last Saturday of February 2013"
-include = true
 
 [0b63e682-f429-4d19-9809-4a45bd0242dc]
 description = "last Sunday of March 2013"
-include = true
 
 [5232307e-d3e3-4afc-8ba6-4084ad987c00]
 description = "last Sunday of April 2013"
-include = true
 
 [0bbd48e8-9773-4e81-8e71-b9a51711e3c5]
 description = "last Wednesday of February 2012"
-include = true
 
 [fe0936de-7eee-4a48-88dd-66c07ab1fefc]
 description = "last Wednesday of December 2014"
-include = true
 
 [2ccf2488-aafc-4671-a24e-2b6effe1b0e2]
 description = "last Sunday of February 2015"
-include = true
 
 [00c3ce9f-cf36-4b70-90d8-92b32be6830e]
 description = "first Friday of December 2012"
-include = true

--- a/exercises/practice/minesweeper/.meta/tests.toml
+++ b/exercises/practice/minesweeper/.meta/tests.toml
@@ -4,48 +4,36 @@
 
 [0c5ec4bd-dea7-4138-8651-1203e1cb9f44]
 description = "no rows"
-include = true
 
 [650ac4c0-ad6b-4b41-acde-e4ea5852c3b8]
 description = "no columns"
-include = true
 
 [6fbf8f6d-a03b-42c9-9a58-b489e9235478]
 description = "no mines"
-include = true
 
 [61aff1c4-fb31-4078-acad-cd5f1e635655]
 description = "minefield with only mines"
-include = true
 
 [84167147-c504-4896-85d7-246b01dea7c5]
 description = "mine surrounded by spaces"
-include = true
 
 [cb878f35-43e3-4c9d-93d9-139012cccc4a]
 description = "space surrounded by mines"
-include = true
 
 [7037f483-ddb4-4b35-b005-0d0f4ef4606f]
 description = "horizontal line"
-include = true
 
 [e359820f-bb8b-4eda-8762-47b64dba30a6]
 description = "horizontal line, mines at edges"
-include = true
 
 [c5198b50-804f-47e9-ae02-c3b42f7ce3ab]
 description = "vertical line"
-include = true
 
 [0c79a64d-703d-4660-9e90-5adfa5408939]
 description = "vertical line, mines at edges"
-include = true
 
 [4b098563-b7f3-401c-97c6-79dd1b708f34]
 description = "cross"
-include = true
 
 [04a260f1-b40a-4e89-839e-8dd8525abe0e]
 description = "large minefield"
-include = true

--- a/exercises/practice/nth-prime/.meta/tests.toml
+++ b/exercises/practice/nth-prime/.meta/tests.toml
@@ -4,20 +4,15 @@
 
 [75c65189-8aef-471a-81de-0a90c728160c]
 description = "first prime"
-include = true
 
 [2c38804c-295f-4701-b728-56dea34fd1a0]
 description = "second prime"
-include = true
 
 [56692534-781e-4e8c-b1f9-3e82c1640259]
 description = "sixth prime"
-include = true
 
 [fce1e979-0edb-412d-93aa-2c744e8f50ff]
 description = "big prime"
-include = true
 
 [bd0a9eae-6df7-485b-a144-80e13c7d55b2]
 description = "there is no zeroth prime"
-include = true

--- a/exercises/practice/nucleotide-count/.meta/tests.toml
+++ b/exercises/practice/nucleotide-count/.meta/tests.toml
@@ -4,20 +4,15 @@
 
 [3e5c30a8-87e2-4845-a815-a49671ade970]
 description = "empty strand"
-include = true
 
 [a0ea42a6-06d9-4ac6-828c-7ccaccf98fec]
 description = "can count one nucleotide in single-character input"
-include = true
 
 [eca0d565-ed8c-43e7-9033-6cefbf5115b5]
 description = "strand with repeated nucleotide"
-include = true
 
 [40a45eac-c83f-4740-901a-20b22d15a39f]
 description = "strand with multiple nucleotides"
-include = true
 
 [b4c47851-ee9e-4b0a-be70-a86e343bd851]
 description = "strand with invalid nucleotides"
-include = true

--- a/exercises/practice/ocr-numbers/.meta/tests.toml
+++ b/exercises/practice/ocr-numbers/.meta/tests.toml
@@ -4,68 +4,51 @@
 
 [5ee54e1a-b554-4bf3-a056-9a7976c3f7e8]
 description = "Recognizes 0"
-include = true
 
 [027ada25-17fd-4d78-aee6-35a19623639d]
 description = "Recognizes 1"
-include = true
 
 [3cce2dbd-01d9-4f94-8fae-419a822e89bb]
 description = "Unreadable but correctly sized inputs return ?"
-include = true
 
 [cb19b733-4e36-4cf9-a4a1-6e6aac808b9a]
 description = "Input with a number of lines that is not a multiple of four raises an error"
-include = true
 
 [235f7bd1-991b-4587-98d4-84206eec4cc6]
 description = "Input with a number of columns that is not a multiple of three raises an error"
-include = true
 
 [4a841794-73c9-4da9-a779-1f9837faff66]
 description = "Recognizes 110101100"
-include = true
 
 [70c338f9-85b1-4296-a3a8-122901cdfde8]
 description = "Garbled numbers in a string are replaced with ?"
-include = true
 
 [ea494ff4-3610-44d7-ab7e-72fdef0e0802]
 description = "Recognizes 2"
-include = true
 
 [1acd2c00-412b-4268-93c2-bd7ff8e05a2c]
 description = "Recognizes 3"
-include = true
 
 [eaec6a15-be17-4b6d-b895-596fae5d1329]
 description = "Recognizes 4"
-include = true
 
 [440f397a-f046-4243-a6ca-81ab5406c56e]
 description = "Recognizes 5"
-include = true
 
 [f4c9cf6a-f1e2-4878-bfc3-9b85b657caa0]
 description = "Recognizes 6"
-include = true
 
 [e24ebf80-c611-41bb-a25a-ac2c0f232df5]
 description = "Recognizes 7"
-include = true
 
 [b79cad4f-e264-4818-9d9e-77766792e233]
 description = "Recognizes 8"
-include = true
 
 [5efc9cfc-9227-4688-b77d-845049299e66]
 description = "Recognizes 9"
-include = true
 
 [f60cb04a-42be-494e-a535-3451c8e097a4]
 description = "Recognizes string of decimal numbers"
-include = true
 
 [b73ecf8b-4423-4b36-860d-3710bdb8a491]
 description = "Numbers separated by empty lines are recognized. Lines are joined by commas."
-include = true

--- a/exercises/practice/palindrome-products/.meta/tests.toml
+++ b/exercises/practice/palindrome-products/.meta/tests.toml
@@ -4,48 +4,36 @@
 
 [5cff78fe-cf02-459d-85c2-ce584679f887]
 description = "finds the smallest palindrome from single digit factors"
-include = true
 
 [0853f82c-5fc4-44ae-be38-fadb2cced92d]
 description = "finds the largest palindrome from single digit factors"
-include = true
 
 [66c3b496-bdec-4103-9129-3fcb5a9063e1]
 description = "find the smallest palindrome from double digit factors"
-include = true
 
 [a10682ae-530a-4e56-b89d-69664feafe53]
 description = "find the largest palindrome from double digit factors"
-include = true
 
 [cecb5a35-46d1-4666-9719-fa2c3af7499d]
 description = "find smallest palindrome from triple digit factors"
-include = true
 
 [edab43e1-c35f-4ea3-8c55-2f31dddd92e5]
 description = "find the largest palindrome from triple digit factors"
-include = true
 
 [4f802b5a-9d74-4026-a70f-b53ff9234e4e]
 description = "find smallest palindrome from four digit factors"
-include = true
 
 [787525e0-a5f9-40f3-8cb2-23b52cf5d0be]
 description = "find the largest palindrome from four digit factors"
-include = true
 
 [58fb1d63-fddb-4409-ab84-a7a8e58d9ea0]
 description = "empty result for smallest if no palindrome in the range"
-include = true
 
 [9de9e9da-f1d9-49a5-8bfc-3d322efbdd02]
 description = "empty result for largest if no palindrome in the range"
-include = true
 
 [12e73aac-d7ee-4877-b8aa-2aa3dcdb9f8a]
 description = "error result for smallest if min is more than max"
-include = true
 
 [eeeb5bff-3f47-4b1e-892f-05829277bd74]
 description = "error result for largest if min is more than max"
-include = true

--- a/exercises/practice/pangram/.meta/tests.toml
+++ b/exercises/practice/pangram/.meta/tests.toml
@@ -4,40 +4,30 @@
 
 [64f61791-508e-4f5c-83ab-05de042b0149]
 description = "empty sentence"
-include = true
 
 [74858f80-4a4d-478b-8a5e-c6477e4e4e84]
 description = "perfect lower case"
-include = true
 
 [61288860-35ca-4abe-ba08-f5df76ecbdcd]
 description = "only lower case"
-include = true
 
 [6564267d-8ac5-4d29-baf2-e7d2e304a743]
 description = "missing the letter 'x'"
-include = true
 
 [c79af1be-d715-4cdb-a5f2-b2fa3e7e0de0]
 description = "missing the letter 'h'"
-include = true
 
 [d835ec38-bc8f-48e4-9e36-eb232427b1df]
 description = "with underscores"
-include = true
 
 [8cc1e080-a178-4494-b4b3-06982c9be2a8]
 description = "with numbers"
-include = true
 
 [bed96b1c-ff95-45b8-9731-fdbdcb6ede9a]
 description = "missing letters replaced by numbers"
-include = true
 
 [938bd5d8-ade5-40e2-a2d9-55a338a01030]
 description = "mixed case and punctuation"
-include = true
 
 [2577bf54-83c8-402d-a64b-a2c0f7bb213a]
 description = "case insensitive"
-include = true

--- a/exercises/practice/pascals-triangle/.meta/tests.toml
+++ b/exercises/practice/pascals-triangle/.meta/tests.toml
@@ -4,32 +4,24 @@
 
 [9920ce55-9629-46d5-85d6-4201f4a4234d]
 description = "zero rows"
-include = true
 
 [70d643ce-a46d-4e93-af58-12d88dd01f21]
 description = "single row"
-include = true
 
 [a6e5a2a2-fc9a-4b47-9f4f-ed9ad9fbe4bd]
 description = "two rows"
-include = true
 
 [97206a99-79ba-4b04-b1c5-3c0fa1e16925]
 description = "three rows"
-include = true
 
 [565a0431-c797-417c-a2c8-2935e01ce306]
 description = "four rows"
-include = true
 
 [06f9ea50-9f51-4eb2-b9a9-c00975686c27]
 description = "five rows"
-include = true
 
 [c3912965-ddb4-46a9-848e-3363e6b00b13]
 description = "six rows"
-include = true
 
 [6cb26c66-7b57-4161-962c-81ec8c99f16b]
 description = "ten rows"
-include = true

--- a/exercises/practice/perfect-numbers/.meta/tests.toml
+++ b/exercises/practice/perfect-numbers/.meta/tests.toml
@@ -4,52 +4,39 @@
 
 [163e8e86-7bfd-4ee2-bd68-d083dc3381a3]
 description = "Smallest perfect number is classified correctly"
-include = true
 
 [169a7854-0431-4ae0-9815-c3b6d967436d]
 description = "Medium perfect number is classified correctly"
-include = true
 
 [ee3627c4-7b36-4245-ba7c-8727d585f402]
 description = "Large perfect number is classified correctly"
-include = true
 
 [80ef7cf8-9ea8-49b9-8b2d-d9cb3db3ed7e]
 description = "Smallest abundant number is classified correctly"
-include = true
 
 [3e300e0d-1a12-4f11-8c48-d1027165ab60]
 description = "Medium abundant number is classified correctly"
-include = true
 
 [ec7792e6-8786-449c-b005-ce6dd89a772b]
 description = "Large abundant number is classified correctly"
-include = true
 
 [e610fdc7-2b6e-43c3-a51c-b70fb37413ba]
 description = "Smallest prime deficient number is classified correctly"
-include = true
 
 [0beb7f66-753a-443f-8075-ad7fbd9018f3]
 description = "Smallest non-prime deficient number is classified correctly"
-include = true
 
 [1c802e45-b4c6-4962-93d7-1cad245821ef]
 description = "Medium deficient number is classified correctly"
-include = true
 
 [47dd569f-9e5a-4a11-9a47-a4e91c8c28aa]
 description = "Large deficient number is classified correctly"
-include = true
 
 [a696dec8-6147-4d68-afad-d38de5476a56]
 description = "Edge case (no factors other than itself) is classified correctly"
-include = true
 
 [72445cee-660c-4d75-8506-6c40089dc302]
 description = "Zero is rejected (not a natural number)"
-include = true
 
 [2d72ce2c-6802-49ac-8ece-c790ba3dae13]
 description = "Negative integer is rejected (not a natural number)"
-include = true

--- a/exercises/practice/phone-number/.meta/tests.toml
+++ b/exercises/practice/phone-number/.meta/tests.toml
@@ -4,72 +4,54 @@
 
 [79666dce-e0f1-46de-95a1-563802913c35]
 description = "cleans the number"
-include = true
 
 [c360451f-549f-43e4-8aba-fdf6cb0bf83f]
 description = "cleans numbers with dots"
-include = true
 
 [08f94c34-9a37-46a2-a123-2a8e9727395d]
 description = "cleans numbers with multiple spaces"
-include = true
 
 [598d8432-0659-4019-a78b-1c6a73691d21]
 description = "invalid when 9 digits"
-include = true
 
 [57061c72-07b5-431f-9766-d97da7c4399d]
 description = "invalid when 11 digits does not start with a 1"
-include = true
 
 [9962cbf3-97bb-4118-ba9b-38ff49c64430]
 description = "valid when 11 digits and starting with 1"
-include = true
 
 [fa724fbf-054c-4d91-95da-f65ab5b6dbca]
 description = "valid when 11 digits and starting with 1 even with punctuation"
-include = true
 
 [c6a5f007-895a-4fc5-90bc-a7e70f9b5cad]
 description = "invalid when more than 11 digits"
-include = true
 
 [63f38f37-53f6-4a5f-bd86-e9b404f10a60]
 description = "invalid with letters"
-include = true
 
 [4bd97d90-52fd-45d3-b0db-06ab95b1244e]
 description = "invalid with punctuations"
-include = true
 
 [d77d07f8-873c-4b17-8978-5f66139bf7d7]
 description = "invalid if area code starts with 0"
-include = true
 
 [c7485cfb-1e7b-4081-8e96-8cdb3b77f15e]
 description = "invalid if area code starts with 1"
-include = true
 
 [4d622293-6976-413d-b8bf-dd8a94d4e2ac]
 description = "invalid if exchange code starts with 0"
-include = true
 
 [4cef57b4-7d8e-43aa-8328-1e1b89001262]
 description = "invalid if exchange code starts with 1"
-include = true
 
 [9925b09c-1a0d-4960-a197-5d163cbe308c]
 description = "invalid if area code starts with 0 on valid 11-digit number"
-include = true
 
 [3f809d37-40f3-44b5-ad90-535838b1a816]
 description = "invalid if area code starts with 1 on valid 11-digit number"
-include = true
 
 [e08e5532-d621-40d4-b0cc-96c159276b65]
 description = "invalid if exchange code starts with 0 on valid 11-digit number"
-include = true
 
 [57b32f3d-696a-455c-8bf1-137b6d171cdf]
 description = "invalid if exchange code starts with 1 on valid 11-digit number"
-include = true

--- a/exercises/practice/pig-latin/.meta/tests.toml
+++ b/exercises/practice/pig-latin/.meta/tests.toml
@@ -4,88 +4,66 @@
 
 [11567f84-e8c6-4918-aedb-435f0b73db57]
 description = "word beginning with a"
-include = true
 
 [f623f581-bc59-4f45-9032-90c3ca9d2d90]
 description = "word beginning with e"
-include = true
 
 [7dcb08b3-23a6-4e8a-b9aa-d4e859450d58]
 description = "word beginning with i"
-include = true
 
 [0e5c3bff-266d-41c8-909f-364e4d16e09c]
 description = "word beginning with o"
-include = true
 
 [614ba363-ca3c-4e96-ab09-c7320799723c]
 description = "word beginning with u"
-include = true
 
 [bf2538c6-69eb-4fa7-a494-5a3fec911326]
 description = "word beginning with a vowel and followed by a qu"
-include = true
 
 [e5be8a01-2d8a-45eb-abb4-3fcc9582a303]
 description = "word beginning with p"
-include = true
 
 [d36d1e13-a7ed-464d-a282-8820cb2261ce]
 description = "word beginning with k"
-include = true
 
 [d838b56f-0a89-4c90-b326-f16ff4e1dddc]
 description = "word beginning with x"
-include = true
 
 [bce94a7a-a94e-4e2b-80f4-b2bb02e40f71]
 description = "word beginning with q without a following u"
-include = true
 
 [c01e049a-e3e2-451c-bf8e-e2abb7e438b8]
 description = "word beginning with ch"
-include = true
 
 [9ba1669e-c43f-4b93-837a-cfc731fd1425]
 description = "word beginning with qu"
-include = true
 
 [92e82277-d5e4-43d7-8dd3-3a3b316c41f7]
 description = "word beginning with qu and a preceding consonant"
-include = true
 
 [79ae4248-3499-4d5b-af46-5cb05fa073ac]
 description = "word beginning with th"
-include = true
 
 [e0b3ae65-f508-4de3-8999-19c2f8e243e1]
 description = "word beginning with thr"
-include = true
 
 [20bc19f9-5a35-4341-9d69-1627d6ee6b43]
 description = "word beginning with sch"
-include = true
 
 [54b796cb-613d-4509-8c82-8fbf8fc0af9e]
 description = "word beginning with yt"
-include = true
 
 [8c37c5e1-872e-4630-ba6e-d20a959b67f6]
 description = "word beginning with xr"
-include = true
 
 [a4a36d33-96f3-422c-a233-d4021460ff00]
 description = "y is treated like a consonant at the beginning of a word"
-include = true
 
 [adc90017-1a12-4100-b595-e346105042c7]
 description = "y is treated like a vowel at the end of a consonant cluster"
-include = true
 
 [29b4ca3d-efe5-4a95-9a54-8467f2e5e59a]
 description = "y as second letter in two letter word"
-include = true
 
 [44616581-5ce3-4a81-82d0-40c7ab13d2cf]
 description = "a whole phrase"
-include = true

--- a/exercises/practice/poker/.meta/tests.toml
+++ b/exercises/practice/poker/.meta/tests.toml
@@ -4,112 +4,84 @@
 
 [161f485e-39c2-4012-84cf-bec0c755b66c]
 description = "single hand always wins"
-include = true
 
 [370ac23a-a00f-48a9-9965-6f3fb595cf45]
 description = "highest card out of all hands wins"
-include = true
 
 [d94ad5a7-17df-484b-9932-c64fc26cff52]
 description = "a tie has multiple winners"
-include = true
 
 [61ed83a9-cfaa-40a5-942a-51f52f0a8725]
 description = "multiple hands with the same high cards, tie compares next highest ranked, down to last card"
-include = true
 
 [f7175a89-34ff-44de-b3d7-f6fd97d1fca4]
 description = "one pair beats high card"
-include = true
 
 [e114fd41-a301-4111-a9e7-5a7f72a76561]
 description = "highest pair wins"
-include = true
 
 [935bb4dc-a622-4400-97fa-86e7d06b1f76]
 description = "two pairs beats one pair"
-include = true
 
 [c8aeafe1-6e3d-4711-a6de-5161deca91fd]
 description = "both hands have two pairs, highest ranked pair wins"
-include = true
 
 [88abe1ba-7ad7-40f3-847e-0a26f8e46a60]
 description = "both hands have two pairs, with the same highest ranked pair, tie goes to low pair"
-include = true
 
 [15a7a315-0577-47a3-9981-d6cf8e6f387b]
 description = "both hands have two identically ranked pairs, tie goes to remaining card (kicker)"
-include = true
 
 [21e9f1e6-2d72-49a1-a930-228e5e0195dc]
 description = "three of a kind beats two pair"
-include = true
 
 [c2fffd1f-c287-480f-bf2d-9628e63bbcc3]
 description = "both hands have three of a kind, tie goes to highest ranked triplet"
-include = true
 
 [eb856cc2-481c-4b0d-9835-4d75d07a5d9d]
 description = "with multiple decks, two players can have same three of a kind, ties go to highest remaining cards"
-include = true
 
 [a858c5d9-2f28-48e7-9980-b7fa04060a60]
 description = "a straight beats three of a kind"
-include = true
 
 [73c9c756-e63e-4b01-a88d-0d4491a7a0e3]
 description = "aces can end a straight (10 J Q K A)"
-include = true
 
 [76856b0d-35cd-49ce-a492-fe5db53abc02]
 description = "aces can start a straight (A 2 3 4 5)"
-include = true
 
 [6980c612-bbff-4914-b17a-b044e4e69ea1]
 description = "both hands with a straight, tie goes to highest ranked card"
-include = true
 
 [5135675c-c2fc-4e21-9ba3-af77a32e9ba4]
 description = "even though an ace is usually high, a 5-high straight is the lowest-scoring straight"
-include = true
 
 [c601b5e6-e1df-4ade-b444-b60ce13b2571]
 description = "flush beats a straight"
-include = true
 
 [4d90261d-251c-49bd-a468-896bf10133de]
 description = "both hands have a flush, tie goes to high card, down to the last one if necessary"
-include = true
 
 [3a19361d-8974-455c-82e5-f7152f5dba7c]
 description = "full house beats a flush"
-include = true
 
 [eb73d0e6-b66c-4f0f-b8ba-bf96bc0a67f0]
 description = "both hands have a full house, tie goes to highest-ranked triplet"
-include = true
 
 [34b51168-1e43-4c0d-9b32-e356159b4d5d]
 description = "with multiple decks, both hands have a full house with the same triplet, tie goes to the pair"
-include = true
 
 [d61e9e99-883b-4f99-b021-18f0ae50c5f4]
 description = "four of a kind beats a full house"
-include = true
 
 [2e1c8c63-e0cb-4214-a01b-91954490d2fe]
 description = "both hands have four of a kind, tie goes to high quad"
-include = true
 
 [892ca75d-5474-495d-9f64-a6ce2dcdb7e1]
 description = "with multiple decks, both hands with identical four of a kind, tie determined by kicker"
-include = true
 
 [923bd910-dc7b-4f7d-a330-8b42ec10a3ac]
 description = "straight flush beats four of a kind"
-include = true
 
 [d0927f70-5aec-43db-aed8-1cbd1b6ee9ad]
 description = "both hands have straight flush, tie goes to highest-ranked card"
-include = true

--- a/exercises/practice/pov/.meta/tests.toml
+++ b/exercises/practice/pov/.meta/tests.toml
@@ -4,60 +4,45 @@
 
 [1b3cd134-49ad-4a7d-8376-7087b7e70792]
 description = "Results in the same tree if the input tree is a singleton"
-include = true
 
 [0778c745-0636-40de-9edd-25a8f40426f6]
 description = "Can reroot a tree with a parent and one sibling"
-include = true
 
 [fdfdef0a-4472-4248-8bcf-19cf33f9c06e]
 description = "Can reroot a tree with a parent and many siblings"
-include = true
 
 [cbcf52db-8667-43d8-a766-5d80cb41b4bb]
 description = "Can reroot a tree with new root deeply nested in tree"
-include = true
 
 [e27fa4fa-648d-44cd-90af-d64a13d95e06]
 description = "Moves children of the new root to same level as former parent"
-include = true
 
 [09236c7f-7c83-42cc-87a1-25afa60454a3]
 description = "Can reroot a complex tree with cousins"
-include = true
 
 [f41d5eeb-8973-448f-a3b0-cc1e019a4193]
 description = "Errors if target does not exist in a singleton tree"
-include = true
 
 [9dc0a8b3-df02-4267-9a41-693b6aff75e7]
 description = "Errors if target does not exist in a large tree"
-include = true
 
 [02d1f1d9-428d-4395-b026-2db35ffa8f0a]
 description = "Can find path to parent"
-include = true
 
 [d0002674-fcfb-4cdc-9efa-bfc54e3c31b5]
 description = "Can find path to sibling"
-include = true
 
 [c9877cd1-0a69-40d4-b362-725763a5c38f]
 description = "Can find path to cousin"
-include = true
 
 [9fb17a82-2c14-4261-baa3-2f3f234ffa03]
 description = "Can find path not involving root"
-include = true
 
 [5124ed49-7845-46ad-bc32-97d5ac7451b2]
 description = "Can find path from nodes other than x"
-include = true
 
 [f52a183c-25cc-4c87-9fc9-0e7f81a5725c]
 description = "Errors if destination does not exist"
-include = true
 
 [f4fe18b9-b4a2-4bd5-a694-e179155c2149]
 description = "Errors if source does not exist"
-include = true

--- a/exercises/practice/prime-factors/.meta/tests.toml
+++ b/exercises/practice/prime-factors/.meta/tests.toml
@@ -4,48 +4,36 @@
 
 [924fc966-a8f5-4288-82f2-6b9224819ccd]
 description = "no factors"
-include = true
 
 [17e30670-b105-4305-af53-ddde182cb6ad]
 description = "prime number"
-include = true
 
 [238d57c8-4c12-42ef-af34-ae4929f94789]
 description = "another prime number"
-include = true
 
 [f59b8350-a180-495a-8fb1-1712fbee1158]
 description = "square of a prime"
-include = true
 
 [756949d3-3158-4e3d-91f2-c4f9f043ee70]
 description = "product of first prime"
-include = true
 
 [bc8c113f-9580-4516-8669-c5fc29512ceb]
 description = "cube of a prime"
-include = true
 
 [7d6a3300-a4cb-4065-bd33-0ced1de6cb44]
 description = "product of second prime"
-include = true
 
 [073ac0b2-c915-4362-929d-fc45f7b9a9e4]
 description = "product of third prime"
-include = true
 
 [6e0e4912-7fb6-47f3-a9ad-dbcd79340c75]
 description = "product of first and second prime"
-include = true
 
 [00485cd3-a3fe-4fbe-a64a-a4308fc1f870]
 description = "product of primes and non-primes"
-include = true
 
 [02251d54-3ca1-4a9b-85e1-b38f4b0ccb91]
 description = "product of primes"
-include = true
 
 [070cf8dc-e202-4285-aa37-8d775c9cd473]
 description = "factors include a large prime"
-include = true

--- a/exercises/practice/protein-translation/.meta/tests.toml
+++ b/exercises/practice/protein-translation/.meta/tests.toml
@@ -4,92 +4,69 @@
 
 [96d3d44f-34a2-4db4-84cd-fff523e069be]
 description = "Methionine RNA sequence"
-include = true
 
 [1b4c56d8-d69f-44eb-be0e-7b17546143d9]
 description = "Phenylalanine RNA sequence 1"
-include = true
 
 [81b53646-bd57-4732-b2cb-6b1880e36d11]
 description = "Phenylalanine RNA sequence 2"
-include = true
 
 [42f69d4f-19d2-4d2c-a8b0-f0ae9ee1b6b4]
 description = "Leucine RNA sequence 1"
-include = true
 
 [ac5edadd-08ed-40a3-b2b9-d82bb50424c4]
 description = "Leucine RNA sequence 2"
-include = true
 
 [8bc36e22-f984-44c3-9f6b-ee5d4e73f120]
 description = "Serine RNA sequence 1"
-include = true
 
 [5c3fa5da-4268-44e5-9f4b-f016ccf90131]
 description = "Serine RNA sequence 2"
-include = true
 
 [00579891-b594-42b4-96dc-7ff8bf519606]
 description = "Serine RNA sequence 3"
-include = true
 
 [08c61c3b-fa34-4950-8c4a-133945570ef6]
 description = "Serine RNA sequence 4"
-include = true
 
 [54e1e7d8-63c0-456d-91d2-062c72f8eef5]
 description = "Tyrosine RNA sequence 1"
-include = true
 
 [47bcfba2-9d72-46ad-bbce-22f7666b7eb1]
 description = "Tyrosine RNA sequence 2"
-include = true
 
 [3a691829-fe72-43a7-8c8e-1bd083163f72]
 description = "Cysteine RNA sequence 1"
-include = true
 
 [1b6f8a26-ca2f-43b8-8262-3ee446021767]
 description = "Cysteine RNA sequence 2"
-include = true
 
 [1e91c1eb-02c0-48a0-9e35-168ad0cb5f39]
 description = "Tryptophan RNA sequence"
-include = true
 
 [e547af0b-aeab-49c7-9f13-801773a73557]
 description = "STOP codon RNA sequence 1"
-include = true
 
 [67640947-ff02-4f23-a2ef-816f8a2ba72e]
 description = "STOP codon RNA sequence 2"
-include = true
 
 [9c2ad527-ebc9-4ace-808b-2b6447cb54cb]
 description = "STOP codon RNA sequence 3"
-include = true
 
 [d0f295df-fb70-425c-946c-ec2ec185388e]
 description = "Translate RNA strand into correct protein list"
-include = true
 
 [e30e8505-97ec-4e5f-a73e-5726a1faa1f4]
 description = "Translation stops if STOP codon at beginning of sequence"
-include = true
 
 [5358a20b-6f4c-4893-bce4-f929001710f3]
 description = "Translation stops if STOP codon at end of two-codon sequence"
-include = true
 
 [ba16703a-1a55-482f-bb07-b21eef5093a3]
 description = "Translation stops if STOP codon at end of three-codon sequence"
-include = true
 
 [4089bb5a-d5b4-4e71-b79e-b8d1f14a2911]
 description = "Translation stops if STOP codon in middle of three-codon sequence"
-include = true
 
 [2c2a2a60-401f-4a80-b977-e0715b23b93d]
 description = "Translation stops if STOP codon in middle of six-codon sequence"
-include = true

--- a/exercises/practice/proverb/.meta/tests.toml
+++ b/exercises/practice/proverb/.meta/tests.toml
@@ -4,24 +4,18 @@
 
 [e974b73e-7851-484f-8d6d-92e07fe742fc]
 description = "zero pieces"
-include = true
 
 [2fcd5f5e-8b82-4e74-b51d-df28a5e0faa4]
 description = "one piece"
-include = true
 
 [d9d0a8a1-d933-46e2-aa94-eecf679f4b0e]
 description = "two pieces"
-include = true
 
 [c95ef757-5e94-4f0d-a6cb-d2083f5e5a83]
 description = "three pieces"
-include = true
 
 [433fb91c-35a2-4d41-aeab-4de1e82b2126]
 description = "full proverb"
-include = true
 
 [c1eefa5a-e8d9-41c7-91d4-99fab6d6b9f7]
 description = "four pieces modernized"
-include = true

--- a/exercises/practice/pythagorean-triplet/.meta/tests.toml
+++ b/exercises/practice/pythagorean-triplet/.meta/tests.toml
@@ -4,28 +4,21 @@
 
 [a19de65d-35b8-4480-b1af-371d9541e706]
 description = "triplets whose sum is 12"
-include = true
 
 [48b21332-0a3d-43b2-9a52-90b2a6e5c9f5]
 description = "triplets whose sum is 108"
-include = true
 
 [dffc1266-418e-4daa-81af-54c3e95c3bb5]
 description = "triplets whose sum is 1000"
-include = true
 
 [5f86a2d4-6383-4cce-93a5-e4489e79b186]
 description = "no matching triplets for 1001"
-include = true
 
 [bf17ba80-1596-409a-bb13-343bdb3b2904]
 description = "returns all matching triplets"
-include = true
 
 [9d8fb5d5-6c6f-42df-9f95-d3165963ac57]
 description = "several matching triplets"
-include = true
 
 [f5be5734-8aa0-4bd1-99a2-02adcc4402b4]
 description = "triplets for large number"
-include = true

--- a/exercises/practice/queen-attack/.meta/tests.toml
+++ b/exercises/practice/queen-attack/.meta/tests.toml
@@ -4,48 +4,36 @@
 
 [3ac4f735-d36c-44c4-a3e2-316f79704203]
 description = "queen with a valid position"
-include = true
 
 [4e812d5d-b974-4e38-9a6b-8e0492bfa7be]
 description = "queen must have positive row"
-include = true
 
 [f07b7536-b66b-4f08-beb9-4d70d891d5c8]
 description = "queen must have row on board"
-include = true
 
 [15a10794-36d9-4907-ae6b-e5a0d4c54ebe]
 description = "queen must have positive column"
-include = true
 
 [6907762d-0e8a-4c38-87fb-12f2f65f0ce4]
 description = "queen must have column on board"
-include = true
 
 [33ae4113-d237-42ee-bac1-e1e699c0c007]
 description = "can not attack"
-include = true
 
 [eaa65540-ea7c-4152-8c21-003c7a68c914]
 description = "can attack on same row"
-include = true
 
 [bae6f609-2c0e-4154-af71-af82b7c31cea]
 description = "can attack on same column"
-include = true
 
 [0e1b4139-b90d-4562-bd58-dfa04f1746c7]
 description = "can attack on first diagonal"
-include = true
 
 [ff9b7ed4-e4b6-401b-8d16-bc894d6d3dcd]
 description = "can attack on second diagonal"
-include = true
 
 [0a71e605-6e28-4cc2-aa47-d20a2e71037a]
 description = "can attack on third diagonal"
-include = true
 
 [0790b588-ae73-4f1f-a968-dd0b34f45f86]
 description = "can attack on fourth diagonal"
-include = true

--- a/exercises/practice/rail-fence-cipher/.meta/tests.toml
+++ b/exercises/practice/rail-fence-cipher/.meta/tests.toml
@@ -4,24 +4,18 @@
 
 [46dc5c50-5538-401d-93a5-41102680d068]
 description = "encode with two rails"
-include = true
 
 [25691697-fbd8-4278-8c38-b84068b7bc29]
 description = "encode with three rails"
-include = true
 
 [384f0fea-1442-4f1a-a7c4-5cbc2044002c]
 description = "encode with ending in the middle"
-include = true
 
 [cd525b17-ec34-45ef-8f0e-4f27c24a7127]
 description = "decode with three rails"
-include = true
 
 [dd7b4a98-1a52-4e5c-9499-cbb117833507]
 description = "decode with five rails"
-include = true
 
 [93e1ecf4-fac9-45d9-9cd2-591f47d3b8d3]
 description = "decode with six rails"
-include = true

--- a/exercises/practice/raindrops/.meta/tests.toml
+++ b/exercises/practice/raindrops/.meta/tests.toml
@@ -4,72 +4,54 @@
 
 [1575d549-e502-46d4-a8e1-6b7bec6123d8]
 description = "the sound for 1 is 1"
-include = true
 
 [1f51a9f9-4895-4539-b182-d7b0a5ab2913]
 description = "the sound for 3 is Pling"
-include = true
 
 [2d9bfae5-2b21-4bcd-9629-c8c0e388f3e0]
 description = "the sound for 5 is Plang"
-include = true
 
 [d7e60daa-32ef-4c23-b688-2abff46c4806]
 description = "the sound for 7 is Plong"
-include = true
 
 [6bb4947b-a724-430c-923f-f0dc3d62e56a]
 description = "the sound for 6 is Pling as it has a factor 3"
-include = true
 
 [ce51e0e8-d9d4-446d-9949-96eac4458c2d]
 description = "2 to the power 3 does not make a raindrop sound as 3 is the exponent not the base"
-include = true
 
 [0dd66175-e3e2-47fc-8750-d01739856671]
 description = "the sound for 9 is Pling as it has a factor 3"
-include = true
 
 [022c44d3-2182-4471-95d7-c575af225c96]
 description = "the sound for 10 is Plang as it has a factor 5"
-include = true
 
 [37ab74db-fed3-40ff-b7b9-04acdfea8edf]
 description = "the sound for 14 is Plong as it has a factor of 7"
-include = true
 
 [31f92999-6afb-40ee-9aa4-6d15e3334d0f]
 description = "the sound for 15 is PlingPlang as it has factors 3 and 5"
-include = true
 
 [ff9bb95d-6361-4602-be2c-653fe5239b54]
 description = "the sound for 21 is PlingPlong as it has factors 3 and 7"
-include = true
 
 [d2e75317-b72e-40ab-8a64-6734a21dece1]
 description = "the sound for 25 is Plang as it has a factor 5"
-include = true
 
 [a09c4c58-c662-4e32-97fe-f1501ef7125c]
 description = "the sound for 27 is Pling as it has a factor 3"
-include = true
 
 [bdf061de-8564-4899-a843-14b48b722789]
 description = "the sound for 35 is PlangPlong as it has factors 5 and 7"
-include = true
 
 [c4680bee-69ba-439d-99b5-70c5fd1a7a83]
 description = "the sound for 49 is Plong as it has a factor 7"
-include = true
 
 [17f2bc9a-b65a-4d23-8ccd-266e8c271444]
 description = "the sound for 52 is 52"
-include = true
 
 [e46677ed-ff1a-419f-a740-5c713d2830e4]
 description = "the sound for 105 is PlingPlangPlong as it has factors 3, 5 and 7"
-include = true
 
 [13c6837a-0fcd-4b86-a0eb-20572f7deb0b]
 description = "the sound for 3125 is Plang as it has a factor 5"
-include = true

--- a/exercises/practice/rational-numbers/.meta/tests.toml
+++ b/exercises/practice/rational-numbers/.meta/tests.toml
@@ -4,152 +4,114 @@
 
 [0ba4d988-044c-4ed5-9215-4d0bb8d0ae9f]
 description = "Add two positive rational numbers"
-include = true
 
 [88ebc342-a2ac-4812-a656-7b664f718b6a]
 description = "Add a positive rational number and a negative rational number"
-include = true
 
 [92ed09c2-991e-4082-a602-13557080205c]
 description = "Add two negative rational numbers"
-include = true
 
 [6e58999e-3350-45fb-a104-aac7f4a9dd11]
 description = "Add a rational number to its additive inverse"
-include = true
 
 [47bba350-9db1-4ab9-b412-4a7e1f72a66e]
 description = "Subtract two positive rational numbers"
-include = true
 
 [93926e2a-3e82-4aee-98a7-fc33fb328e87]
 description = "Subtract a positive rational number and a negative rational number"
-include = true
 
 [a965ba45-9b26-442b-bdc7-7728e4b8d4cc]
 description = "Subtract two negative rational numbers"
-include = true
 
 [0df0e003-f68e-4209-8c6e-6a4e76af5058]
 description = "Subtract a rational number from itself"
-include = true
 
 [34fde77a-75f4-4204-8050-8d3a937958d3]
 description = "Multiply two positive rational numbers"
-include = true
 
 [6d015cf0-0ea3-41f1-93de-0b8e38e88bae]
 description = "Multiply a negative rational number by a positive rational number"
-include = true
 
 [d1bf1b55-954e-41b1-8c92-9fc6beeb76fa]
 description = "Multiply two negative rational numbers"
-include = true
 
 [a9b8f529-9ec7-4c79-a517-19365d779040]
 description = "Multiply a rational number by its reciprocal"
-include = true
 
 [d89d6429-22fa-4368-ab04-9e01a44d3b48]
 description = "Multiply a rational number by 1"
-include = true
 
 [0d95c8b9-1482-4ed7-bac9-b8694fa90145]
 description = "Multiply a rational number by 0"
-include = true
 
 [1de088f4-64be-4e6e-93fd-5997ae7c9798]
 description = "Divide two positive rational numbers"
-include = true
 
 [7d7983db-652a-4e66-981a-e921fb38d9a9]
 description = "Divide a positive rational number by a negative rational number"
-include = true
 
 [1b434d1b-5b38-4cee-aaf5-b9495c399e34]
 description = "Divide two negative rational numbers"
-include = true
 
 [d81c2ebf-3612-45a6-b4e0-f0d47812bd59]
 description = "Divide a rational number by 1"
-include = true
 
 [5fee0d8e-5955-4324-acbe-54cdca94ddaa]
 description = "Absolute value of a positive rational number"
-include = true
 
 [3cb570b6-c36a-4963-a380-c0834321bcaa]
 description = "Absolute value of a positive rational number with negative numerator and denominator"
-include = true
 
 [6a05f9a0-1f6b-470b-8ff7-41af81773f25]
 description = "Absolute value of a negative rational number"
-include = true
 
 [5d0f2336-3694-464f-8df9-f5852fda99dd]
 description = "Absolute value of a negative rational number with negative denominator"
-include = true
 
 [f8e1ed4b-9dca-47fb-a01e-5311457b3118]
 description = "Absolute value of zero"
-include = true
 
 [ea2ad2af-3dab-41e7-bb9f-bd6819668a84]
 description = "Raise a positive rational number to a positive integer power"
-include = true
 
 [8168edd2-0af3-45b1-b03f-72c01332e10a]
 description = "Raise a negative rational number to a positive integer power"
-include = true
 
 [e2f25b1d-e4de-4102-abc3-c2bb7c4591e4]
 description = "Raise zero to an integer power"
-include = true
 
 [431cac50-ab8b-4d58-8e73-319d5404b762]
 description = "Raise one to an integer power"
-include = true
 
 [7d164739-d68a-4a9c-b99f-dd77ce5d55e6]
 description = "Raise a positive rational number to the power of zero"
-include = true
 
 [eb6bd5f5-f880-4bcd-8103-e736cb6e41d1]
 description = "Raise a negative rational number to the power of zero"
-include = true
 
 [30b467dd-c158-46f5-9ffb-c106de2fd6fa]
 description = "Raise a real number to a positive rational number"
-include = true
 
 [6e026bcc-be40-4b7b-ae22-eeaafc5a1789]
 description = "Raise a real number to a negative rational number"
-include = true
 
 [9f866da7-e893-407f-8cd2-ee85d496eec5]
 description = "Raise a real number to a zero rational number"
-include = true
 
 [0a63fbde-b59c-4c26-8237-1e0c73354d0a]
 description = "Reduce a positive rational number to lowest terms"
-include = true
 
 [f87c2a4e-d29c-496e-a193-318c503e4402]
 description = "Reduce a negative rational number to lowest terms"
-include = true
 
 [3b92ffc0-5b70-4a43-8885-8acee79cdaaf]
 description = "Reduce a rational number with a negative denominator to lowest terms"
-include = true
 
 [c9dbd2e6-5ac0-4a41-84c1-48b645b4f663]
 description = "Reduce zero to lowest terms"
-include = true
 
 [297b45ad-2054-4874-84d4-0358dc1b8887]
 description = "Reduce an integer to lowest terms"
-include = true
 
 [a73a17fe-fe8c-4a1c-a63b-e7579e333d9e]
 description = "Reduce one to lowest terms"
-include = true

--- a/exercises/practice/react/.meta/tests.toml
+++ b/exercises/practice/react/.meta/tests.toml
@@ -4,56 +4,42 @@
 
 [c51ee736-d001-4f30-88d1-0c8e8b43cd07]
 description = "input cells have a value"
-include = true
 
 [dedf0fe0-da0c-4d5d-a582-ffaf5f4d0851]
 description = "an input cell's value can be set"
-include = true
 
 [5854b975-f545-4f93-8968-cc324cde746e]
 description = "compute cells calculate initial value"
-include = true
 
 [25795a3d-b86c-4e91-abe7-1c340e71560c]
 description = "compute cells take inputs in the right order"
-include = true
 
 [c62689bf-7be5-41bb-b9f8-65178ef3e8ba]
 description = "compute cells update value when dependencies are changed"
-include = true
 
 [5ff36b09-0a88-48d4-b7f8-69dcf3feea40]
 description = "compute cells can depend on other compute cells"
-include = true
 
 [abe33eaf-68ad-42a5-b728-05519ca88d2d]
 description = "compute cells fire callbacks"
-include = true
 
 [9e5cb3a4-78e5-4290-80f8-a78612c52db2]
 description = "callback cells only fire on change"
-include = true
 
 [ada17cb6-7332-448a-b934-e3d7495c13d3]
 description = "callbacks do not report already reported values"
-include = true
 
 [ac271900-ea5c-461c-9add-eeebcb8c03e5]
 description = "callbacks can fire from multiple cells"
-include = true
 
 [95a82dcc-8280-4de3-a4cd-4f19a84e3d6f]
 description = "callbacks can be added and removed"
-include = true
 
 [f2a7b445-f783-4e0e-8393-469ab4915f2a]
 description = "removing a callback multiple times doesn't interfere with other callbacks"
-include = true
 
 [daf6feca-09e0-4ce5-801d-770ddfe1c268]
 description = "callbacks should only be called once even if multiple dependencies change"
-include = true
 
 [9a5b159f-b7aa-4729-807e-f1c38a46d377]
 description = "callbacks should not be called if dependencies change but output value doesn't change"
-include = true

--- a/exercises/practice/rectangles/.meta/tests.toml
+++ b/exercises/practice/rectangles/.meta/tests.toml
@@ -4,52 +4,39 @@
 
 [485b7bab-4150-40aa-a8db-73013427d08c]
 description = "no rows"
-include = true
 
 [076929ed-27e8-45dc-b14b-08279944dc49]
 description = "no columns"
-include = true
 
 [0a8abbd1-a0a4-4180-aa4e-65c1b1a073fa]
 description = "no rectangles"
-include = true
 
 [a4ba42e9-4e7f-4973-b7c7-4ce0760ac6cd]
 description = "one rectangle"
-include = true
 
 [ced06550-83da-4d23-98b7-d24152e0db93]
 description = "two rectangles without shared parts"
-include = true
 
 [5942d69a-a07c-41c8-8b93-2d13877c706a]
 description = "five rectangles with shared parts"
-include = true
 
 [82d70be4-ab37-4bf2-a433-e33778d3bbf1]
 description = "rectangle of height 1 is counted"
-include = true
 
 [57f1bc0e-2782-401e-ab12-7c01d8bfc2e0]
 description = "rectangle of width 1 is counted"
-include = true
 
 [ef0bb65c-bd80-4561-9535-efc4067054f9]
 description = "1x1 square is counted"
-include = true
 
 [e1e1d444-e926-4d30-9bf3-7d8ec9a9e330]
 description = "only complete rectangles are counted"
-include = true
 
 [ca021a84-1281-4a56-9b9b-af14113933a4]
 description = "rectangles can be of different sizes"
-include = true
 
 [51f689a7-ef3f-41ae-aa2f-5ea09ad897ff]
 description = "corner is required for a rectangle to be complete"
-include = true
 
 [d78fe379-8c1b-4d3c-bdf7-29bfb6f6dc66]
 description = "large input with many rectangles"
-include = true

--- a/exercises/practice/resistor-color-duo/.meta/tests.toml
+++ b/exercises/practice/resistor-color-duo/.meta/tests.toml
@@ -4,20 +4,15 @@
 
 [ce11995a-5b93-4950-a5e9-93423693b2fc]
 description = "Brown and black"
-include = true
 
 [7bf82f7a-af23-48ba-a97d-38d59406a920]
 description = "Blue and grey"
-include = true
 
 [f1886361-fdfd-4693-acf8-46726fe24e0c]
 description = "Yellow and violet"
-include = true
 
 [77a8293d-2a83-4016-b1af-991acc12b9fe]
 description = "Orange and orange"
-include = true
 
 [0c4fb44f-db7c-4d03-afa8-054350f156a8]
 description = "Ignore additional colors"
-include = true

--- a/exercises/practice/resistor-color-trio/.meta/tests.toml
+++ b/exercises/practice/resistor-color-trio/.meta/tests.toml
@@ -4,20 +4,15 @@
 
 [d6863355-15b7-40bb-abe0-bfb1a25512ed]
 description = "Orange and orange and black"
-include = true
 
 [1224a3a9-8c8e-4032-843a-5224e04647d6]
 description = "Blue and grey and brown"
-include = true
 
 [b8bda7dc-6b95-4539-abb2-2ad51d66a207]
 description = "Red and black and red"
-include = true
 
 [5b1e74bc-d838-4eda-bbb3-eaba988e733b]
 description = "Green and brown and orange"
-include = true
 
 [f5d37ef9-1919-4719-a90d-a33c5a6934c9]
 description = "Yellow and violet and yellow"
-include = true

--- a/exercises/practice/resistor-color/.meta/tests.toml
+++ b/exercises/practice/resistor-color/.meta/tests.toml
@@ -4,16 +4,12 @@
 
 [49eb31c5-10a8-4180-9f7f-fea632ab87ef]
 description = "Black"
-include = true
 
 [0a4df94b-92da-4579-a907-65040ce0b3fc]
 description = "White"
-include = true
 
 [5f81608d-f36f-4190-8084-f45116b6f380]
 description = "Orange"
-include = true
 
 [581d68fa-f968-4be2-9f9d-880f2fb73cf7]
 description = "Colors"
-include = true

--- a/exercises/practice/rest-api/.meta/tests.toml
+++ b/exercises/practice/rest-api/.meta/tests.toml
@@ -4,36 +4,27 @@
 
 [5be01ffb-a814-47a8-a19f-490a5622ba07]
 description = "no users"
-include = true
 
 [382b70cc-9f6c-486d-9bee-fda2df81c803]
 description = "add user"
-include = true
 
 [d624e5e5-1abb-4f18-95b3-45d55c818dc3]
 description = "get single user"
-include = true
 
 [7a81b82c-7276-433e-8fce-29ce983a7c56]
 description = "both users have 0 balance"
-include = true
 
 [1c61f957-cf8c-48ba-9e77-b221ab068803]
 description = "borrower has negative balance"
-include = true
 
 [8a8567b3-c097-468a-9541-6bb17d5afc85]
 description = "lender has negative balance"
-include = true
 
 [29fb7c12-7099-4a85-a7c4-9c290d2dc01a]
 description = "lender owes borrower"
-include = true
 
 [ce969e70-163c-4135-a4a6-2c3a5da286f5]
 description = "lender owes borrower less than new loan"
-include = true
 
 [7f4aafd9-ae9b-4e15-a406-87a87bdf47a4]
 description = "lender owes borrower same as new loan"
-include = true

--- a/exercises/practice/reverse-string/.meta/tests.toml
+++ b/exercises/practice/reverse-string/.meta/tests.toml
@@ -4,24 +4,18 @@
 
 [c3b7d806-dced-49ee-8543-933fd1719b1c]
 description = "an empty string"
-include = true
 
 [01ebf55b-bebb-414e-9dec-06f7bb0bee3c]
 description = "a word"
-include = true
 
 [0f7c07e4-efd1-4aaa-a07a-90b49ce0b746]
 description = "a capitalized word"
-include = true
 
 [71854b9c-f200-4469-9f5c-1e8e5eff5614]
 description = "a sentence with punctuation"
-include = true
 
 [1f8ed2f3-56f3-459b-8f3e-6d8d654a1f6c]
 description = "a palindrome"
-include = true
 
 [b9e7dec1-c6df-40bd-9fa3-cd7ded010c4c]
 description = "an even-sized word"
-include = true

--- a/exercises/practice/rna-transcription/.meta/tests.toml
+++ b/exercises/practice/rna-transcription/.meta/tests.toml
@@ -4,24 +4,18 @@
 
 [b4631f82-c98c-4a2f-90b3-c5c2b6c6f661]
 description = "Empty RNA sequence"
-include = true
 
 [a9558a3c-318c-4240-9256-5d5ed47005a6]
 description = "RNA complement of cytosine is guanine"
-include = true
 
 [6eedbb5c-12cb-4c8b-9f51-f8320b4dc2e7]
 description = "RNA complement of guanine is cytosine"
-include = true
 
 [870bd3ec-8487-471d-8d9a-a25046488d3e]
 description = "RNA complement of thymine is adenine"
-include = true
 
 [aade8964-02e1-4073-872f-42d3ffd74c5f]
 description = "RNA complement of adenine is uracil"
-include = true
 
 [79ed2757-f018-4f47-a1d7-34a559392dbf]
 description = "RNA complement"
-include = true

--- a/exercises/practice/robot-simulator/.meta/tests.toml
+++ b/exercises/practice/robot-simulator/.meta/tests.toml
@@ -4,72 +4,54 @@
 
 [c557c16d-26c1-4e06-827c-f6602cd0785c]
 description = "at origin facing north"
-include = true
 
 [bf0dffce-f11c-4cdb-8a5e-2c89d8a5a67d]
 description = "at negative position facing south"
-include = true
 
 [8cbd0086-6392-4680-b9b9-73cf491e67e5]
 description = "changes north to east"
-include = true
 
 [8abc87fc-eab2-4276-93b7-9c009e866ba1]
 description = "changes east to south"
-include = true
 
 [3cfe1b85-bbf2-4bae-b54d-d73e7e93617a]
 description = "changes south to west"
-include = true
 
 [5ea9fb99-3f2c-47bd-86f7-46b7d8c3c716]
 description = "changes west to north"
-include = true
 
 [fa0c40f5-6ba3-443d-a4b3-58cbd6cb8d63]
 description = "changes north to west"
-include = true
 
 [da33d734-831f-445c-9907-d66d7d2a92e2]
 description = "changes west to south"
-include = true
 
 [bd1ca4b9-4548-45f4-b32e-900fc7c19389]
 description = "changes south to east"
-include = true
 
 [2de27b67-a25c-4b59-9883-bc03b1b55bba]
 description = "changes east to north"
-include = true
 
 [f0dc2388-cddc-4f83-9bed-bcf46b8fc7b8]
 description = "facing north increments Y"
-include = true
 
 [2786cf80-5bbf-44b0-9503-a89a9c5789da]
 description = "facing south decrements Y"
-include = true
 
 [84bf3c8c-241f-434d-883d-69817dbd6a48]
 description = "facing east increments X"
-include = true
 
 [bb69c4a7-3bbf-4f64-b415-666fa72d7b04]
 description = "facing west decrements X"
-include = true
 
 [e34ac672-4ed4-4be3-a0b8-d9af259cbaa1]
 description = "moving east and north from README"
-include = true
 
 [f30e4955-4b47-4aa3-8b39-ae98cfbd515b]
 description = "moving west and north"
-include = true
 
 [3e466bf6-20ab-4d79-8b51-264165182fca]
 description = "moving west and south"
-include = true
 
 [41f0bb96-c617-4e6b-acff-a4b279d44514]
 description = "moving east and north"
-include = true

--- a/exercises/practice/roman-numerals/.meta/tests.toml
+++ b/exercises/practice/roman-numerals/.meta/tests.toml
@@ -4,76 +4,57 @@
 
 [19828a3a-fbf7-4661-8ddd-cbaeee0e2178]
 description = "1 is a single I"
-include = true
 
 [f088f064-2d35-4476-9a41-f576da3f7b03]
 description = "2 is two I's"
-include = true
 
 [b374a79c-3bea-43e6-8db8-1286f79c7106]
 description = "3 is three I's"
-include = true
 
 [05a0a1d4-a140-4db1-82e8-fcc21fdb49bb]
 description = "4, being 5 - 1, is IV"
-include = true
 
 [57c0f9ad-5024-46ab-975d-de18c430b290]
 description = "5 is a single V"
-include = true
 
 [20a2b47f-e57f-4797-a541-0b3825d7f249]
 description = "6, being 5 + 1, is VI"
-include = true
 
 [ff3fb08c-4917-4aab-9f4e-d663491d083d]
 description = "9, being 10 - 1, is IX"
-include = true
 
 [2bda64ca-7d28-4c56-b08d-16ce65716cf6]
 description = "20 is two X's"
-include = true
 
 [a1f812ef-84da-4e02-b4f0-89c907d0962c]
 description = "48 is not 50 - 2 but rather 40 + 8"
-include = true
 
 [607ead62-23d6-4c11-a396-ef821e2e5f75]
 description = "49 is not 40 + 5 + 4 but rather 50 - 10 + 10 - 1"
-include = true
 
 [d5b283d4-455d-4e68-aacf-add6c4b51915]
 description = "50 is a single L"
-include = true
 
 [46b46e5b-24da-4180-bfe2-2ef30b39d0d0]
 description = "90, being 100 - 10, is XC"
-include = true
 
 [30494be1-9afb-4f84-9d71-db9df18b55e3]
 description = "100 is a single C"
-include = true
 
 [267f0207-3c55-459a-b81d-67cec7a46ed9]
 description = "60, being 50 + 10, is LX"
-include = true
 
 [cdb06885-4485-4d71-8bfb-c9d0f496b404]
 description = "400, being 500 - 100, is CD"
-include = true
 
 [6b71841d-13b2-46b4-ba97-dec28133ea80]
 description = "500 is a single D"
-include = true
 
 [432de891-7fd6-4748-a7f6-156082eeca2f]
 description = "900, being 1000 - 100, is CM"
-include = true
 
 [e6de6d24-f668-41c0-88d7-889c0254d173]
 description = "1000 is a single M"
-include = true
 
 [bb550038-d4eb-4be2-a9ce-f21961ac3bc6]
 description = "3000 is three M's"
-include = true

--- a/exercises/practice/rotational-cipher/.meta/tests.toml
+++ b/exercises/practice/rotational-cipher/.meta/tests.toml
@@ -4,40 +4,30 @@
 
 [74e58a38-e484-43f1-9466-877a7515e10f]
 description = "rotate a by 0, same output as input"
-include = true
 
 [7ee352c6-e6b0-4930-b903-d09943ecb8f5]
 description = "rotate a by 1"
-include = true
 
 [edf0a733-4231-4594-a5ee-46a4009ad764]
 description = "rotate a by 26, same output as input"
-include = true
 
 [e3e82cb9-2a5b-403f-9931-e43213879300]
 description = "rotate m by 13"
-include = true
 
 [19f9eb78-e2ad-4da4-8fe3-9291d47c1709]
 description = "rotate n by 13 with wrap around alphabet"
-include = true
 
 [a116aef4-225b-4da9-884f-e8023ca6408a]
 description = "rotate capital letters"
-include = true
 
 [71b541bb-819c-4dc6-a9c3-132ef9bb737b]
 description = "rotate spaces"
-include = true
 
 [ef32601d-e9ef-4b29-b2b5-8971392282e6]
 description = "rotate numbers"
-include = true
 
 [32dd74f6-db2b-41a6-b02c-82eb4f93e549]
 description = "rotate punctuation"
-include = true
 
 [9fb93fe6-42b0-46e6-9ec1-0bf0a062d8c9]
 description = "rotate all letters"
-include = true

--- a/exercises/practice/run-length-encoding/.meta/tests.toml
+++ b/exercises/practice/run-length-encoding/.meta/tests.toml
@@ -4,52 +4,39 @@
 
 [ad53b61b-6ffc-422f-81a6-61f7df92a231]
 description = "empty string"
-include = true
 
 [52012823-b7e6-4277-893c-5b96d42f82de]
 description = "single characters only are encoded without count"
-include = true
 
 [b7868492-7e3a-415f-8da3-d88f51f80409]
 description = "string with no single characters"
-include = true
 
 [859b822b-6e9f-44d6-9c46-6091ee6ae358]
 description = "single characters mixed with repeated characters"
-include = true
 
 [1b34de62-e152-47be-bc88-469746df63b3]
 description = "multiple whitespace mixed in string"
-include = true
 
 [abf176e2-3fbd-40ad-bb2f-2dd6d4df721a]
 description = "lowercase characters"
-include = true
 
 [7ec5c390-f03c-4acf-ac29-5f65861cdeb5]
 description = "empty string"
-include = true
 
 [ad23f455-1ac2-4b0e-87d0-b85b10696098]
 description = "single characters only"
-include = true
 
 [21e37583-5a20-4a0e-826c-3dee2c375f54]
 description = "string with no single characters"
-include = true
 
 [1389ad09-c3a8-4813-9324-99363fba429c]
 description = "single characters with repeated characters"
-include = true
 
 [3f8e3c51-6aca-4670-b86c-a213bf4706b0]
 description = "multiple whitespace mixed in string"
-include = true
 
 [29f721de-9aad-435f-ba37-7662df4fb551]
 description = "lower case string"
-include = true
 
 [2a762efd-8695-4e04-b0d6-9736899fbc16]
 description = "encode followed by decode gives original string"
-include = true

--- a/exercises/practice/saddle-points/.meta/tests.toml
+++ b/exercises/practice/saddle-points/.meta/tests.toml
@@ -4,36 +4,27 @@
 
 [3e374e63-a2e0-4530-a39a-d53c560382bd]
 description = "Can identify single saddle point"
-include = true
 
 [6b501e2b-6c1f-491f-b1bb-7f278f760534]
 description = "Can identify that empty matrix has no saddle points"
-include = true
 
 [8c27cc64-e573-4fcb-a099-f0ae863fb02f]
 description = "Can identify lack of saddle points when there are none"
-include = true
 
 [6d1399bd-e105-40fd-a2c9-c6609507d7a3]
 description = "Can identify multiple saddle points in a column"
-include = true
 
 [3e81dce9-53b3-44e6-bf26-e328885fd5d1]
 description = "Can identify multiple saddle points in a row"
-include = true
 
 [88868621-b6f4-4837-bb8b-3fad8b25d46b]
 description = "Can identify saddle point in bottom right corner"
-include = true
 
 [5b9499ca-fcea-4195-830a-9c4584a0ee79]
 description = "Can identify saddle points in a non square matrix"
-include = true
 
 [ee99ccd2-a1f1-4283-ad39-f8c70f0cf594]
 description = "Can identify that saddle points in a single column matrix are those with the minimum value"
-include = true
 
 [63abf709-a84b-407f-a1b3-456638689713]
 description = "Can identify that saddle points in a single row matrix are those with the maximum value"
-include = true

--- a/exercises/practice/satellite/.meta/tests.toml
+++ b/exercises/practice/satellite/.meta/tests.toml
@@ -4,24 +4,18 @@
 
 [8df3fa26-811a-4165-9286-ff9ac0850d19]
 description = "Empty tree"
-include = true
 
 [f945ccfc-05e3-47d7-825b-0270559d43ad]
 description = "Tree with one item"
-include = true
 
 [a0121d5f-37b0-48dd-9c64-cba4c4464135]
 description = "Tree with many items"
-include = true
 
 [6074041f-4891-4d81-a128-401050c2a3b0]
 description = "Reject traversals of different length"
-include = true
 
 [27916ce4-45f3-4d8b-8528-496fedc157ca]
 description = "Reject inconsistent traversals of same length"
-include = true
 
 [d86a3d72-76a9-43b5-9d3a-e64cb1216035]
 description = "Reject traversals with repeated items"
-include = true

--- a/exercises/practice/say/.meta/tests.toml
+++ b/exercises/practice/say/.meta/tests.toml
@@ -4,60 +4,45 @@
 
 [5d22a120-ba0c-428c-bd25-8682235d83e8]
 description = "zero"
-include = true
 
 [9b5eed77-dbf6-439d-b920-3f7eb58928f6]
 description = "one"
-include = true
 
 [7c499be1-612e-4096-a5e1-43b2f719406d]
 description = "fourteen"
-include = true
 
 [f541dd8e-f070-4329-92b4-b7ce2fcf06b4]
 description = "twenty"
-include = true
 
 [d78601eb-4a84-4bfa-bf0e-665aeb8abe94]
 description = "twenty-two"
-include = true
 
 [e417d452-129e-4056-bd5b-6eb1df334dce]
 description = "one hundred"
-include = true
 
 [d6924f30-80ba-4597-acf6-ea3f16269da8]
 description = "one hundred twenty-three"
-include = true
 
 [3d83da89-a372-46d3-b10d-de0c792432b3]
 description = "one thousand"
-include = true
 
 [865af898-1d5b-495f-8ff0-2f06d3c73709]
 description = "one thousand two hundred thirty-four"
-include = true
 
 [b6a3f442-266e-47a3-835d-7f8a35f6cf7f]
 description = "one million"
-include = true
 
 [2cea9303-e77e-4212-b8ff-c39f1978fc70]
 description = "one million two thousand three hundred forty-five"
-include = true
 
 [3e240eeb-f564-4b80-9421-db123f66a38f]
 description = "one billion"
-include = true
 
 [9a43fed1-c875-4710-8286-5065d73b8a9e]
 description = "a big number"
-include = true
 
 [49a6a17b-084e-423e-994d-a87c0ecc05ef]
 description = "numbers below zero are out of range"
-include = true
 
 [4d6492eb-5853-4d16-9d34-b0f61b261fd9]
 description = "numbers above 999,999,999,999 are out of range"
-include = true

--- a/exercises/practice/scale-generator/.meta/tests.toml
+++ b/exercises/practice/scale-generator/.meta/tests.toml
@@ -4,68 +4,51 @@
 
 [10ea7b14-8a49-40be-ac55-7c62b55f9b47]
 description = "Chromatic scale with sharps"
-include = true
 
 [af8381de-9a72-4efd-823a-48374dbfe76f]
 description = "Chromatic scale with flats"
-include = true
 
 [6f5b1410-1dd7-4c6c-b410-6b7e986f6f1e]
 description = "Simple major scale"
-include = true
 
 [13a92f89-a83e-40b5-b9d4-01136931ba02]
 description = "Major scale with sharps"
-include = true
 
 [aa3320f6-a761-49a1-bcf6-978e0c81080a]
 description = "Major scale with flats"
-include = true
 
 [63daeb2f-c3f9-4c45-92be-5bf97f61ff94]
 description = "Minor scale with sharps"
-include = true
 
 [616594d0-9c48-4301-949e-af1d4fad16fd]
 description = "Minor scale with flats"
-include = true
 
 [390bd12c-5ac7-4ec7-bdde-4e58d5c78b0a]
 description = "Dorian mode"
-include = true
 
 [846d0862-0f3e-4f3b-8a2d-9cc74f017848]
 description = "Mixolydian mode"
-include = true
 
 [7d49a8bb-b5f7-46ad-a207-83bd5032291a]
 description = "Lydian mode"
-include = true
 
 [a4e4dac5-1891-4160-a19f-bb06d653d4d0]
 description = "Phrygian mode"
-include = true
 
 [ef3650af-90f8-4ad9-9ef6-fdbeae07dcaa]
 description = "Locrian mode"
-include = true
 
 [70517400-12b7-4530-b861-fa940ae69ee8]
 description = "Harmonic minor"
-include = true
 
 [37114c0b-c54d-45da-9f4b-3848201470b0]
 description = "Octatonic"
-include = true
 
 [496466e7-aa45-4bbd-a64d-f41030feed9c]
 description = "Hexatonic"
-include = true
 
 [bee5d9ec-e226-47b6-b62b-847a9241f3cc]
 description = "Pentatonic"
-include = true
 
 [dbee06a6-7535-4ab7-98e8-d8a36c8402d1]
 description = "Enigmatic"
-include = true

--- a/exercises/practice/scrabble-score/.meta/tests.toml
+++ b/exercises/practice/scrabble-score/.meta/tests.toml
@@ -4,44 +4,33 @@
 
 [f46cda29-1ca5-4ef2-bd45-388a767e3db2]
 description = "lowercase letter"
-include = true
 
 [f7794b49-f13e-45d1-a933-4e48459b2201]
 description = "uppercase letter"
-include = true
 
 [eaba9c76-f9fa-49c9-a1b0-d1ba3a5b31fa]
 description = "valuable letter"
-include = true
 
 [f3c8c94e-bb48-4da2-b09f-e832e103151e]
 description = "short word"
-include = true
 
 [71e3d8fa-900d-4548-930e-68e7067c4615]
 description = "short, valuable word"
-include = true
 
 [d3088ad9-570c-4b51-8764-c75d5a430e99]
 description = "medium word"
-include = true
 
 [fa20c572-ad86-400a-8511-64512daac352]
 description = "medium, valuable word"
-include = true
 
 [9336f0ba-9c2b-4fa0-bd1c-2e2d328cf967]
 description = "long, mixed-case word"
-include = true
 
 [1e34e2c3-e444-4ea7-b598-3c2b46fd2c10]
 description = "english-like word"
-include = true
 
 [4efe3169-b3b6-4334-8bae-ff4ef24a7e4f]
 description = "empty input"
-include = true
 
 [3b305c1c-f260-4e15-a5b5-cb7d3ea7c3d7]
 description = "entire alphabet available"
-include = true

--- a/exercises/practice/secret-handshake/.meta/tests.toml
+++ b/exercises/practice/secret-handshake/.meta/tests.toml
@@ -4,44 +4,33 @@
 
 [b8496fbd-6778-468c-8054-648d03c4bb23]
 description = "wink for 1"
-include = true
 
 [83ec6c58-81a9-4fd1-bfaf-0160514fc0e3]
 description = "double blink for 10"
-include = true
 
 [0e20e466-3519-4134-8082-5639d85fef71]
 description = "close your eyes for 100"
-include = true
 
 [b339ddbb-88b7-4b7d-9b19-4134030d9ac0]
 description = "jump for 1000"
-include = true
 
 [40499fb4-e60c-43d7-8b98-0de3ca44e0eb]
 description = "combine two actions"
-include = true
 
 [9730cdd5-ef27-494b-afd3-5c91ad6c3d9d]
 description = "reverse two actions"
-include = true
 
 [0b828205-51ca-45cd-90d5-f2506013f25f]
 description = "reversing one action gives the same action"
-include = true
 
 [9949e2ac-6c9c-4330-b685-2089ab28b05f]
 description = "reversing no actions still gives no actions"
-include = true
 
 [23fdca98-676b-4848-970d-cfed7be39f81]
 description = "all possible actions"
-include = true
 
 [ae8fe006-d910-4d6f-be00-54b7c3799e79]
 description = "reverse all possible actions"
-include = true
 
 [3d36da37-b31f-4cdb-a396-d93a2ee1c4a5]
 description = "do nothing for zero"
-include = true

--- a/exercises/practice/series/.meta/tests.toml
+++ b/exercises/practice/series/.meta/tests.toml
@@ -4,40 +4,30 @@
 
 [7ae7a46a-d992-4c2a-9c15-a112d125ebad]
 description = "slices of one from one"
-include = true
 
 [3143b71d-f6a5-4221-aeae-619f906244d2]
 description = "slices of one from two"
-include = true
 
 [dbb68ff5-76c5-4ccd-895a-93dbec6d5805]
 description = "slices of two"
-include = true
 
 [19bbea47-c987-4e11-a7d1-e103442adf86]
 description = "slices of two overlap"
-include = true
 
 [8e17148d-ba0a-4007-a07f-d7f87015d84c]
 description = "slices can include duplicates"
-include = true
 
 [bd5b085e-f612-4f81-97a8-6314258278b0]
 description = "slices of a long series"
-include = true
 
 [6d235d85-46cf-4fae-9955-14b6efef27cd]
 description = "slice length is too large"
-include = true
 
 [d34004ad-8765-4c09-8ba1-ada8ce776806]
 description = "slice length cannot be zero"
-include = true
 
 [10ab822d-8410-470a-a85d-23fbeb549e54]
 description = "slice length cannot be negative"
-include = true
 
 [c7ed0812-0e4b-4bf3-99c4-28cbbfc246a2]
 description = "empty series is invalid"
-include = true

--- a/exercises/practice/sieve/.meta/tests.toml
+++ b/exercises/practice/sieve/.meta/tests.toml
@@ -4,20 +4,15 @@
 
 [88529125-c4ce-43cc-bb36-1eb4ddd7b44f]
 description = "no primes under two"
-include = true
 
 [4afe9474-c705-4477-9923-840e1024cc2b]
 description = "find first prime"
-include = true
 
 [974945d8-8cd9-4f00-9463-7d813c7f17b7]
 description = "find primes up to 10"
-include = true
 
 [2e2417b7-3f3a-452a-8594-b9af08af6d82]
 description = "limit is prime"
-include = true
 
 [92102a05-4c7c-47de-9ed0-b7d5fcd00f21]
 description = "find primes up to 1000"
-include = true

--- a/exercises/practice/simple-cipher/.meta/tests.toml
+++ b/exercises/practice/simple-cipher/.meta/tests.toml
@@ -4,48 +4,36 @@
 
 [b8bdfbe1-bea3-41bb-a999-b41403f2b15d]
 description = "Can encode"
-include = true
 
 [3dff7f36-75db-46b4-ab70-644b3f38b81c]
 description = "Can decode"
-include = true
 
 [8143c684-6df6-46ba-bd1f-dea8fcb5d265]
 description = "Is reversible. I.e., if you apply decode in a encoded result, you must see the same plaintext encode parameter as a result of the decode method"
-include = true
 
 [defc0050-e87d-4840-85e4-51a1ab9dd6aa]
 description = "Key is made only of lowercase letters"
-include = true
 
 [565e5158-5b3b-41dd-b99d-33b9f413c39f]
 description = "Can encode"
-include = true
 
 [d44e4f6a-b8af-4e90-9d08-fd407e31e67b]
 description = "Can decode"
-include = true
 
 [70a16473-7339-43df-902d-93408c69e9d1]
 description = "Is reversible. I.e., if you apply decode in a encoded result, you must see the same plaintext encode parameter as a result of the decode method"
-include = true
 
 [69a1458b-92a6-433a-a02d-7beac3ea91f9]
 description = "Can double shift encode"
-include = true
 
 [21d207c1-98de-40aa-994f-86197ae230fb]
 description = "Can wrap on encode"
-include = true
 
 [a3d7a4d7-24a9-4de6-bdc4-a6614ced0cb3]
 description = "Can wrap on decode"
-include = true
 
 [e31c9b8c-8eb6-45c9-a4b5-8344a36b9641]
 description = "Can encode messages longer than the key"
-include = true
 
 [93cfaae0-17da-4627-9a04-d6d1e1be52e3]
 description = "Can decode messages longer than the key"
-include = true

--- a/exercises/practice/space-age/.meta/tests.toml
+++ b/exercises/practice/space-age/.meta/tests.toml
@@ -4,32 +4,24 @@
 
 [84f609af-5a91-4d68-90a3-9e32d8a5cd34]
 description = "age on Earth"
-include = true
 
 [ca20c4e9-6054-458c-9312-79679ffab40b]
 description = "age on Mercury"
-include = true
 
 [502c6529-fd1b-41d3-8fab-65e03082b024]
 description = "age on Venus"
-include = true
 
 [9ceadf5e-a0d5-4388-9d40-2c459227ceb8]
 description = "age on Mars"
-include = true
 
 [42927dc3-fe5e-4f76-a5b5-f737fc19bcde]
 description = "age on Jupiter"
-include = true
 
 [8469b332-7837-4ada-b27c-00ee043ebcad]
 description = "age on Saturn"
-include = true
 
 [999354c1-76f8-4bb5-a672-f317b6436743]
 description = "age on Uranus"
-include = true
 
 [80096d30-a0d4-4449-903e-a381178355d8]
 description = "age on Neptune"
-include = true

--- a/exercises/practice/spiral-matrix/.meta/tests.toml
+++ b/exercises/practice/spiral-matrix/.meta/tests.toml
@@ -4,24 +4,18 @@
 
 [8f584201-b446-4bc9-b132-811c8edd9040]
 description = "empty spiral"
-include = true
 
 [e40ae5f3-e2c9-4639-8116-8a119d632ab2]
 description = "trivial spiral"
-include = true
 
 [cf05e42d-eb78-4098-a36e-cdaf0991bc48]
 description = "spiral of size 2"
-include = true
 
 [1c475667-c896-4c23-82e2-e033929de939]
 description = "spiral of size 3"
-include = true
 
 [05ccbc48-d891-44f5-9137-f4ce462a759d]
 description = "spiral of size 4"
-include = true
 
 [f4d2165b-1738-4e0c-bed0-c459045ae50d]
 description = "spiral of size 5"
-include = true

--- a/exercises/practice/square-root/.meta/tests.toml
+++ b/exercises/practice/square-root/.meta/tests.toml
@@ -4,24 +4,18 @@
 
 [9b748478-7b0a-490c-b87a-609dacf631fd]
 description = "root of 1"
-include = true
 
 [7d3aa9ba-9ac6-4e93-a18b-2e8b477139bb]
 description = "root of 4"
-include = true
 
 [6624aabf-3659-4ae0-a1c8-25ae7f33c6ef]
 description = "root of 25"
-include = true
 
 [93beac69-265e-4429-abb1-94506b431f81]
 description = "root of 81"
-include = true
 
 [fbddfeda-8c4f-4bc4-87ca-6991af35360e]
 description = "root of 196"
-include = true
 
 [c03d0532-8368-4734-a8e0-f96a9eb7fc1d]
 description = "root of 65025"
-include = true

--- a/exercises/practice/sublist/.meta/tests.toml
+++ b/exercises/practice/sublist/.meta/tests.toml
@@ -4,68 +4,51 @@
 
 [97319c93-ebc5-47ab-a022-02a1980e1d29]
 description = "empty lists"
-include = true
 
 [de27dbd4-df52-46fe-a336-30be58457382]
 description = "empty list within non empty list"
-include = true
 
 [5487cfd1-bc7d-429f-ac6f-1177b857d4fb]
 description = "non empty list contains empty list"
-include = true
 
 [1f390b47-f6b2-4a93-bc23-858ba5dda9a6]
 description = "list equals itself"
-include = true
 
 [7ed2bfb2-922b-4363-ae75-f3a05e8274f5]
 description = "different lists"
-include = true
 
 [3b8a2568-6144-4f06-b0a1-9d266b365341]
 description = "false start"
-include = true
 
 [dc39ed58-6311-4814-be30-05a64bc8d9b1]
 description = "consecutive"
-include = true
 
 [d1270dab-a1ce-41aa-b29d-b3257241ac26]
 description = "sublist at start"
-include = true
 
 [81f3d3f7-4f25-4ada-bcdc-897c403de1b6]
 description = "sublist in middle"
-include = true
 
 [43bcae1e-a9cf-470e-923e-0946e04d8fdd]
 description = "sublist at end"
-include = true
 
 [76cf99ed-0ff0-4b00-94af-4dfb43fe5caa]
 description = "at start of superlist"
-include = true
 
 [b83989ec-8bdf-4655-95aa-9f38f3e357fd]
 description = "in middle of superlist"
-include = true
 
 [26f9f7c3-6cf6-4610-984a-662f71f8689b]
 description = "at end of superlist"
-include = true
 
 [0a6db763-3588-416a-8f47-76b1cedde31e]
 description = "first list missing element from second list"
-include = true
 
 [83ffe6d8-a445-4a3c-8795-1e51a95e65c3]
 description = "second list missing element from first list"
-include = true
 
 [0d7ee7c1-0347-45c8-9ef5-b88db152b30b]
 description = "order matters to a list"
-include = true
 
 [5f47ce86-944e-40f9-9f31-6368aad70aa6]
 description = "same digits but different numbers"
-include = true

--- a/exercises/practice/sum-of-multiples/.meta/tests.toml
+++ b/exercises/practice/sum-of-multiples/.meta/tests.toml
@@ -4,64 +4,48 @@
 
 [54aaab5a-ce86-4edc-8b40-d3ab2400a279]
 description = "no multiples within limit"
-include = true
 
 [361e4e50-c89b-4f60-95ef-5bc5c595490a]
 description = "one factor has multiples within limit"
-include = true
 
 [e644e070-040e-4ae0-9910-93c69fc3f7ce]
 description = "more than one multiple within limit"
-include = true
 
 [607d6eb9-535c-41ce-91b5-3a61da3fa57f]
 description = "more than one factor with multiples within limit"
-include = true
 
 [f47e8209-c0c5-4786-b07b-dc273bf86b9b]
 description = "each multiple is only counted once"
-include = true
 
 [28c4b267-c980-4054-93e9-07723db615ac]
 description = "a much larger limit"
-include = true
 
 [09c4494d-ff2d-4e0f-8421-f5532821ee12]
 description = "three factors"
-include = true
 
 [2d0d5faa-f177-4ad6-bde9-ebb865083751]
 description = "factors not relatively prime"
-include = true
 
 [ece8f2e8-96aa-4166-bbb7-6ce71261e354]
 description = "some pairs of factors relatively prime and some not"
-include = true
 
 [624fdade-6ffb-400e-8472-456a38c171c0]
 description = "one factor is a multiple of another"
-include = true
 
 [949ee7eb-db51-479c-b5cb-4a22b40ac057]
 description = "much larger factors"
-include = true
 
 [41093673-acbd-482c-ab80-d00a0cbedecd]
 description = "all numbers are multiples of 1"
-include = true
 
 [1730453b-baaa-438e-a9c2-d754497b2a76]
 description = "no factors means an empty sum"
-include = true
 
 [214a01e9-f4bf-45bb-80f1-1dce9fbb0310]
 description = "the only multiple of 0 is 0"
-include = true
 
 [c423ae21-a0cb-4ec7-aeb1-32971af5b510]
 description = "the factor 0 does not affect the sum of multiples of other factors"
-include = true
 
 [17053ba9-112f-4ac0-aadb-0519dd836342]
 description = "solutions using include-exclude must extend to cardinality greater than 3"
-include = true

--- a/exercises/practice/tournament/.meta/tests.toml
+++ b/exercises/practice/tournament/.meta/tests.toml
@@ -4,44 +4,33 @@
 
 [67e9fab1-07c1-49cf-9159-bc8671cc7c9c]
 description = "just the header if no input"
-include = true
 
 [1b4a8aef-0734-4007-80a2-0626178c88f4]
 description = "a win is three points, a loss is zero points"
-include = true
 
 [5f45ac09-4efe-46e7-8ddb-75ad85f86e05]
 description = "a win can also be expressed as a loss"
-include = true
 
 [fd297368-efa0-442d-9f37-dd3f9a437239]
 description = "a different team can win"
-include = true
 
 [26c016f9-e753-4a93-94e9-842f7b4d70fc]
 description = "a draw is one point each"
-include = true
 
 [731204f6-4f34-4928-97eb-1c307ba83e62]
 description = "There can be more than one match"
-include = true
 
 [49dc2463-42af-4ea6-95dc-f06cc5776adf]
 description = "There can be more than one winner"
-include = true
 
 [6d930f33-435c-4e6f-9e2d-63fa85ce7dc7]
 description = "There can be more than two teams"
-include = true
 
 [97022974-0c8a-4a50-8fe7-e36bdd8a5945]
 description = "typical input"
-include = true
 
 [fe562f0d-ac0a-4c62-b9c9-44ee3236392b]
 description = "incomplete competition (not all pairs have played)"
-include = true
 
 [3aa0386f-150b-4f99-90bb-5195e7b7d3b8]
 description = "ties broken alphabetically"
-include = true

--- a/exercises/practice/transpose/.meta/tests.toml
+++ b/exercises/practice/transpose/.meta/tests.toml
@@ -4,48 +4,36 @@
 
 [404b7262-c050-4df0-a2a2-0cb06cd6a821]
 description = "empty string"
-include = true
 
 [a89ce8a3-c940-4703-a688-3ea39412fbcb]
 description = "two characters in a row"
-include = true
 
 [855bb6ae-4180-457c-abd0-ce489803ce98]
 description = "two characters in a column"
-include = true
 
 [5ceda1c0-f940-441c-a244-0ced197769c8]
 description = "simple"
-include = true
 
 [a54675dd-ae7d-4a58-a9c4-0c20e99a7c1f]
 description = "single line"
-include = true
 
 [0dc2ec0b-549d-4047-aeeb-8029fec8d5c5]
 description = "first line longer than second line"
-include = true
 
 [984e2ec3-b3d3-4b53-8bd6-96f5ef404102]
 description = "second line longer than first line"
-include = true
 
 [eccd3784-45f0-4a3f-865a-360cb323d314]
 description = "mixed line length"
-include = true
 
 [85b96b3f-d00c-4f80-8ca2-c8a5c9216c2d]
 description = "square"
-include = true
 
 [b9257625-7a53-4748-8863-e08e9d27071d]
 description = "rectangle"
-include = true
 
 [b80badc9-057e-4543-bd07-ce1296a1ea2c]
 description = "triangle"
-include = true
 
 [76acfd50-5596-4d05-89f1-5116328a7dd9]
 description = "jagged triangle"
-include = true

--- a/exercises/practice/triangle/.meta/tests.toml
+++ b/exercises/practice/triangle/.meta/tests.toml
@@ -4,76 +4,57 @@
 
 [8b2c43ac-7257-43f9-b552-7631a91988af]
 description = "all sides are equal"
-include = true
 
 [33eb6f87-0498-4ccf-9573-7f8c3ce92b7b]
 description = "any side is unequal"
-include = true
 
 [c6585b7d-a8c0-4ad8-8a34-e21d36f7ad87]
 description = "no sides are equal"
-include = true
 
 [16e8ceb0-eadb-46d1-b892-c50327479251]
 description = "all zero sides is not a triangle"
-include = true
 
 [3022f537-b8e5-4cc1-8f12-fd775827a00c]
 description = "sides may be floats"
-include = true
 
 [cbc612dc-d75a-4c1c-87fc-e2d5edd70b71]
 description = "last two sides are equal"
-include = true
 
 [e388ce93-f25e-4daf-b977-4b7ede992217]
 description = "first two sides are equal"
-include = true
 
 [d2080b79-4523-4c3f-9d42-2da6e81ab30f]
 description = "first and last sides are equal"
-include = true
 
 [8d71e185-2bd7-4841-b7e1-71689a5491d8]
 description = "equilateral triangles are also isosceles"
-include = true
 
 [840ed5f8-366f-43c5-ac69-8f05e6f10bbb]
 description = "no sides are equal"
-include = true
 
 [2eba0cfb-6c65-4c40-8146-30b608905eae]
 description = "first triangle inequality violation"
-include = true
 
 [278469cb-ac6b-41f0-81d4-66d9b828f8ac]
 description = "second triangle inequality violation"
-include = true
 
 [90efb0c7-72bb-4514-b320-3a3892e278ff]
 description = "third triangle inequality violation"
-include = true
 
 [adb4ee20-532f-43dc-8d31-e9271b7ef2bc]
 description = "sides may be floats"
-include = true
 
 [e8b5f09c-ec2e-47c1-abec-f35095733afb]
 description = "no sides are equal"
-include = true
 
 [2510001f-b44d-4d18-9872-2303e7977dc1]
 description = "all sides are equal"
-include = true
 
 [c6e15a92-90d9-4fb3-90a2-eef64f8d3e1e]
 description = "two sides are equal"
-include = true
 
 [70ad5154-0033-48b7-af2c-b8d739cd9fdc]
 description = "may not violate triangle inequality"
-include = true
 
 [26d9d59d-f8f1-40d3-ad58-ae4d54123d7d]
 description = "sides may be floats"
-include = true

--- a/exercises/practice/twelve-days/.meta/tests.toml
+++ b/exercises/practice/twelve-days/.meta/tests.toml
@@ -4,60 +4,45 @@
 
 [c0b5a5e6-c89d-49b1-a6b2-9f523bff33f7]
 description = "first day a partridge in a pear tree"
-include = true
 
 [1c64508a-df3d-420a-b8e1-fe408847854a]
 description = "second day two turtle doves"
-include = true
 
 [a919e09c-75b2-4e64-bb23-de4a692060a8]
 description = "third day three french hens"
-include = true
 
 [9bed8631-ec60-4894-a3bb-4f0ec9fbe68d]
 description = "fourth day four calling birds"
-include = true
 
 [cf1024f0-73b6-4545-be57-e9cea565289a]
 description = "fifth day five gold rings"
-include = true
 
 [50bd3393-868a-4f24-a618-68df3d02ff04]
 description = "sixth day six geese-a-laying"
-include = true
 
 [8f29638c-9bf1-4680-94be-e8b84e4ade83]
 description = "seventh day seven swans-a-swimming"
-include = true
 
 [7038d6e1-e377-47ad-8c37-10670a05bc05]
 description = "eighth day eight maids-a-milking"
-include = true
 
 [37a800a6-7a56-4352-8d72-0f51eb37cfe8]
 description = "ninth day nine ladies dancing"
-include = true
 
 [10b158aa-49ff-4b2d-afc3-13af9133510d]
 description = "tenth day ten lords-a-leaping"
-include = true
 
 [08d7d453-f2ba-478d-8df0-d39ea6a4f457]
 description = "eleventh day eleven pipers piping"
-include = true
 
 [0620fea7-1704-4e48-b557-c05bf43967f0]
 description = "twelfth day twelve drummers drumming"
-include = true
 
 [da8b9013-b1e8-49df-b6ef-ddec0219e398]
 description = "recites first three verses of the song"
-include = true
 
 [c095af0d-3137-4653-ad32-bfb899eda24c]
 description = "recites three verses from the middle of the song"
-include = true
 
 [20921bc9-cc52-4627-80b3-198cbbfcf9b7]
 description = "recites the whole song"
-include = true

--- a/exercises/practice/two-bucket/.meta/tests.toml
+++ b/exercises/practice/two-bucket/.meta/tests.toml
@@ -4,36 +4,27 @@
 
 [a6f2b4ba-065f-4dca-b6f0-e3eee51cb661]
 description = "Measure using bucket one of size 3 and bucket two of size 5 - start with bucket one"
-include = true
 
 [6c4ea451-9678-4926-b9b3-68364e066d40]
 description = "Measure using bucket one of size 3 and bucket two of size 5 - start with bucket two"
-include = true
 
 [3389f45e-6a56-46d5-9607-75aa930502ff]
 description = "Measure using bucket one of size 7 and bucket two of size 11 - start with bucket one"
-include = true
 
 [fe0ff9a0-3ea5-4bf7-b17d-6d4243961aa1]
 description = "Measure using bucket one of size 7 and bucket two of size 11 - start with bucket two"
-include = true
 
 [0ee1f57e-da84-44f7-ac91-38b878691602]
 description = "Measure one step using bucket one of size 1 and bucket two of size 3 - start with bucket two"
-include = true
 
 [eb329c63-5540-4735-b30b-97f7f4df0f84]
 description = "Measure using bucket one of size 2 and bucket two of size 3 - start with bucket one and end with bucket two"
-include = true
 
 [449be72d-b10a-4f4b-a959-ca741e333b72]
 description = "Not possible to reach the goal"
-include = true
 
 [aac38b7a-77f4-4d62-9b91-8846d533b054]
 description = "With the same buckets but a different goal, then it is possible"
-include = true
 
 [74633132-0ccf-49de-8450-af4ab2e3b299]
 description = "Goal larger than both buckets is impossible"
-include = true

--- a/exercises/practice/two-fer/.meta/tests.toml
+++ b/exercises/practice/two-fer/.meta/tests.toml
@@ -4,12 +4,9 @@
 
 [1cf3e15a-a3d7-4a87-aeb3-ba1b43bc8dce]
 description = "no name given"
-include = true
 
 [b4c6dbb8-b4fb-42c2-bafd-10785abe7709]
 description = "a name given"
-include = true
 
 [3549048d-1a6e-4653-9a79-b0bda163e8d5]
 description = "another name given"
-include = true

--- a/exercises/practice/variable-length-quantity/.meta/tests.toml
+++ b/exercises/practice/variable-length-quantity/.meta/tests.toml
@@ -4,104 +4,78 @@
 
 [35c9db2e-f781-4c52-b73b-8e76427defd0]
 description = "zero"
-include = true
 
 [be44d299-a151-4604-a10e-d4b867f41540]
 description = "arbitrary single byte"
-include = true
 
 [ea399615-d274-4af6-bbef-a1c23c9e1346]
 description = "largest single byte"
-include = true
 
 [77b07086-bd3f-4882-8476-8dcafee79b1c]
 description = "smallest double byte"
-include = true
 
 [63955a49-2690-4e22-a556-0040648d6b2d]
 description = "arbitrary double byte"
-include = true
 
 [29da7031-0067-43d3-83a7-4f14b29ed97a]
 description = "largest double byte"
-include = true
 
 [3345d2e3-79a9-4999-869e-d4856e3a8e01]
 description = "smallest triple byte"
-include = true
 
 [5df0bc2d-2a57-4300-a653-a75ee4bd0bee]
 description = "arbitrary triple byte"
-include = true
 
 [f51d8539-312d-4db1-945c-250222c6aa22]
 description = "largest triple byte"
-include = true
 
 [da78228b-544f-47b7-8bfe-d16b35bbe570]
 description = "smallest quadruple byte"
-include = true
 
 [11ed3469-a933-46f1-996f-2231e05d7bb6]
 description = "arbitrary quadruple byte"
-include = true
 
 [d5f3f3c3-e0f1-4e7f-aad0-18a44f223d1c]
 description = "largest quadruple byte"
-include = true
 
 [91a18b33-24e7-4bfb-bbca-eca78ff4fc47]
 description = "smallest quintuple byte"
-include = true
 
 [5f34ff12-2952-4669-95fe-2d11b693d331]
 description = "arbitrary quintuple byte"
-include = true
 
 [7489694b-88c3-4078-9864-6fe802411009]
 description = "maximum 32-bit integer input"
-include = true
 
 [f9b91821-cada-4a73-9421-3c81d6ff3661]
 description = "two single-byte values"
-include = true
 
 [68694449-25d2-4974-ba75-fa7bb36db212]
 description = "two multi-byte values"
-include = true
 
 [51a06b5c-de1b-4487-9a50-9db1b8930d85]
 description = "many multi-byte values"
-include = true
 
 [baa73993-4514-4915-bac0-f7f585e0e59a]
 description = "one byte"
-include = true
 
 [72e94369-29f9-46f2-8c95-6c5b7a595aee]
 description = "two bytes"
-include = true
 
 [df5a44c4-56f7-464e-a997-1db5f63ce691]
 description = "three bytes"
-include = true
 
 [1bb58684-f2dc-450a-8406-1f3452aa1947]
 description = "four bytes"
-include = true
 
 [cecd5233-49f1-4dd1-a41a-9840a40f09cd]
 description = "maximum 32-bit integer"
-include = true
 
 [e7d74ba3-8b8e-4bcb-858d-d08302e15695]
 description = "incomplete sequence causes error"
-include = true
 
 [aa378291-9043-4724-bc53-aca1b4a3fcb6]
 description = "incomplete sequence causes error, even if value is zero"
-include = true
 
 [a91e6f5a-c64a-48e3-8a75-ce1a81e0ebee]
 description = "multiple values"
-include = true

--- a/exercises/practice/word-count/.meta/tests.toml
+++ b/exercises/practice/word-count/.meta/tests.toml
@@ -4,52 +4,39 @@
 
 [61559d5f-2cad-48fb-af53-d3973a9ee9ef]
 description = "count one word"
-include = true
 
 [5abd53a3-1aed-43a4-a15a-29f88c09cbbd]
 description = "count one of each word"
-include = true
 
 [2a3091e5-952e-4099-9fac-8f85d9655c0e]
 description = "multiple occurrences of a word"
-include = true
 
 [e81877ae-d4da-4af4-931c-d923cd621ca6]
 description = "handles cramped lists"
-include = true
 
 [7349f682-9707-47c0-a9af-be56e1e7ff30]
 description = "handles expanded lists"
-include = true
 
 [a514a0f2-8589-4279-8892-887f76a14c82]
 description = "ignore punctuation"
-include = true
 
 [d2e5cee6-d2ec-497b-bdc9-3ebe092ce55e]
 description = "include numbers"
-include = true
 
 [dac6bc6a-21ae-4954-945d-d7f716392dbf]
 description = "normalize case"
-include = true
 
 [4185a902-bdb0-4074-864c-f416e42a0f19]
 description = "with apostrophes"
-include = true
 
 [be72af2b-8afe-4337-b151-b297202e4a7b]
 description = "with quotations"
-include = true
 
 [8d6815fe-8a51-4a65-96f9-2fb3f6dc6ed6]
 description = "substrings from the beginning"
-include = true
 
 [c5f4ef26-f3f7-4725-b314-855c04fb4c13]
 description = "multiple spaces not detected as a word"
-include = true
 
 [50176e8a-fe8e-4f4c-b6b6-aa9cf8f20360]
 description = "alternating word separators not detected as a word"
-include = true

--- a/exercises/practice/word-search/.meta/tests.toml
+++ b/exercises/practice/word-search/.meta/tests.toml
@@ -4,80 +4,60 @@
 
 [b4057815-0d01-41f0-9119-6a91f54b2a0a]
 description = "Should accept an initial game grid and a target search word"
-include = true
 
 [6b22bcc5-6cbf-4674-931b-d2edbff73132]
 description = "Should locate one word written left to right"
-include = true
 
 [ff462410-434b-442d-9bc3-3360c75f34a8]
 description = "Should locate the same word written left to right in a different position"
-include = true
 
 [a02febae-6347-443e-b99c-ab0afb0b8fca]
 description = "Should locate a different left to right word"
-include = true
 
 [e42e9987-6304-4e13-8232-fa07d5280130]
 description = "Should locate that different left to right word in a different position"
-include = true
 
 [9bff3cee-49b9-4775-bdfb-d55b43a70b2f]
 description = "Should locate a left to right word in two line grid"
-include = true
 
 [851a35fb-f499-4ec1-9581-395a87903a22]
 description = "Should locate a left to right word in three line grid"
-include = true
 
 [2f3dcf84-ba7d-4b75-8b8d-a3672b32c035]
 description = "Should locate a left to right word in ten line grid"
-include = true
 
 [006d4856-f365-4e84-a18c-7d129ce9eefb]
 description = "Should locate that left to right word in a different position in a ten line grid"
-include = true
 
 [eff7ac9f-ff11-443e-9747-40850c12ab60]
 description = "Should locate a different left to right word in a ten line grid"
-include = true
 
 [dea39f86-8c67-4164-8884-13bfc48bd13b]
 description = "Should locate multiple words"
-include = true
 
 [29e6a6a5-f80c-48a6-8e68-05bbbe187a09]
 description = "Should locate a single word written right to left"
-include = true
 
 [3cf34428-b43f-48b6-b332-ea0b8836011d]
 description = "Should locate multiple words written in different horizontal directions"
-include = true
 
 [2c8cd344-a02f-464b-93b6-8bf1bd890003]
 description = "Should locate words written top to bottom"
-include = true
 
 [9ee1e43d-e59d-4c32-9a5f-6a22d4a1550f]
 description = "Should locate words written bottom to top"
-include = true
 
 [6a21a676-f59e-4238-8e88-9f81015afae9]
 description = "Should locate words written top left to bottom right"
-include = true
 
 [c9125189-1861-4b0d-a14e-ba5dab29ca7c]
 description = "Should locate words written bottom right to top left"
-include = true
 
 [b19e2149-7fc5-41ec-a8a9-9bc6c6c38c40]
 description = "Should locate words written bottom left to top right"
-include = true
 
 [69e1d994-a6d7-4e24-9b5a-db76751c2ef8]
 description = "Should locate words written top right to bottom left"
-include = true
 
 [695531db-69eb-463f-8bad-8de3bf5ef198]
 description = "Should fail to locate a word that is not in the puzzle"
-include = true

--- a/exercises/practice/wordy/.meta/tests.toml
+++ b/exercises/practice/wordy/.meta/tests.toml
@@ -4,92 +4,69 @@
 
 [88bf4b28-0de3-4883-93c7-db1b14aa806e]
 description = "just a number"
-include = true
 
 [bb8c655c-cf42-4dfc-90e0-152fcfd8d4e0]
 description = "addition"
-include = true
 
 [79e49e06-c5ae-40aa-a352-7a3a01f70015]
 description = "more addition"
-include = true
 
 [b345dbe0-f733-44e1-863c-5ae3568f3803]
 description = "addition with negative numbers"
-include = true
 
 [cd070f39-c4cc-45c4-97fb-1be5e5846f87]
 description = "large addition"
-include = true
 
 [0d86474a-cd93-4649-a4fa-f6109a011191]
 description = "subtraction"
-include = true
 
 [30bc8395-5500-4712-a0cf-1d788a529be5]
 description = "multiplication"
-include = true
 
 [34c36b08-8605-4217-bb57-9a01472c427f]
 description = "division"
-include = true
 
 [da6d2ce4-fb94-4d26-8f5f-b078adad0596]
 description = "multiple additions"
-include = true
 
 [7fd74c50-9911-4597-be09-8de7f2fea2bb]
 description = "addition and subtraction"
-include = true
 
 [b120ffd5-bad6-4e22-81c8-5512e8faf905]
 description = "multiple subtraction"
-include = true
 
 [4f4a5749-ef0c-4f60-841f-abcfaf05d2ae]
 description = "subtraction then addition"
-include = true
 
 [312d908c-f68f-42c9-aa75-961623cc033f]
 description = "multiple multiplication"
-include = true
 
 [38e33587-8940-4cc1-bc28-bfd7e3966276]
 description = "addition and multiplication"
-include = true
 
 [3c854f97-9311-46e8-b574-92b60d17d394]
 description = "multiple division"
-include = true
 
 [3ad3e433-8af7-41ec-aa9b-97b42ab49357]
 description = "unknown operation"
-include = true
 
 [8a7e85a8-9e7b-4d46-868f-6d759f4648f8]
 description = "Non math question"
-include = true
 
 [42d78b5f-dbd7-4cdb-8b30-00f794bb24cf]
 description = "reject problem missing an operand"
-include = true
 
 [c2c3cbfc-1a72-42f2-b597-246e617e66f5]
 description = "reject problem with no operands or operators"
-include = true
 
 [4b3df66d-6ed5-4c95-a0a1-d38891fbdab6]
 description = "reject two operations in a row"
-include = true
 
 [6abd7a50-75b4-4665-aa33-2030fd08bab1]
 description = "reject two numbers in a row"
-include = true
 
 [10a56c22-e0aa-405f-b1d2-c642d9c4c9de]
 description = "reject postfix notation"
-include = true
 
 [0035bc63-ac43-4bb5-ad6d-e8651b7d954e]
 description = "reject prefix notation"
-include = true

--- a/exercises/practice/yacht/.meta/tests.toml
+++ b/exercises/practice/yacht/.meta/tests.toml
@@ -4,112 +4,84 @@
 
 [3060e4a5-4063-4deb-a380-a630b43a84b6]
 description = "Yacht"
-include = true
 
 [15026df2-f567-482f-b4d5-5297d57769d9]
 description = "Not Yacht"
-include = true
 
 [36b6af0c-ca06-4666-97de-5d31213957a4]
 description = "Ones"
-include = true
 
 [023a07c8-6c6e-44d0-bc17-efc5e1b8205a]
 description = "Ones, out of order"
-include = true
 
 [7189afac-cccd-4a74-8182-1cb1f374e496]
 description = "No ones"
-include = true
 
 [793c4292-dd14-49c4-9707-6d9c56cee725]
 description = "Twos"
-include = true
 
 [dc41bceb-d0c5-4634-a734-c01b4233a0c6]
 description = "Fours"
-include = true
 
 [f6125417-5c8a-4bca-bc5b-b4b76d0d28c8]
 description = "Yacht counted as threes"
-include = true
 
 [464fc809-96ed-46e4-acb8-d44e302e9726]
 description = "Yacht of 3s counted as fives"
-include = true
 
 [e8a036e0-9d21-443a-8b5f-e15a9e19a761]
 description = "Sixes"
-include = true
 
 [51cb26db-6b24-49af-a9ff-12f53b252eea]
 description = "Full house two small, three big"
-include = true
 
 [1822ca9d-f235-4447-b430-2e8cfc448f0c]
 description = "Full house three small, two big"
-include = true
 
 [b208a3fc-db2e-4363-a936-9e9a71e69c07]
 description = "Two pair is not a full house"
-include = true
 
 [b90209c3-5956-445b-8a0b-0ac8b906b1c2]
 description = "Four of a kind is not a full house"
-include = true
 
 [32a3f4ee-9142-4edf-ba70-6c0f96eb4b0c]
 description = "Yacht is not a full house"
-include = true
 
 [b286084d-0568-4460-844a-ba79d71d79c6]
 description = "Four of a Kind"
-include = true
 
 [f25c0c90-5397-4732-9779-b1e9b5f612ca]
 description = "Yacht can be scored as Four of a Kind"
-include = true
 
 [9f8ef4f0-72bb-401a-a871-cbad39c9cb08]
 description = "Full house is not Four of a Kind"
-include = true
 
 [b4743c82-1eb8-4a65-98f7-33ad126905cd]
 description = "Little Straight"
-include = true
 
 [7ac08422-41bf-459c-8187-a38a12d080bc]
 description = "Little Straight as Big Straight"
-include = true
 
 [97bde8f7-9058-43ea-9de7-0bc3ed6d3002]
 description = "Four in order but not a little straight"
-include = true
 
 [cef35ff9-9c5e-4fd2-ae95-6e4af5e95a99]
 description = "No pairs but not a little straight"
-include = true
 
 [fd785ad2-c060-4e45-81c6-ea2bbb781b9d]
 description = "Minimum is 1, maximum is 5, but not a little straight"
-include = true
 
 [35bd74a6-5cf6-431a-97a3-4f713663f467]
 description = "Big Straight"
-include = true
 
 [87c67e1e-3e87-4f3a-a9b1-62927822b250]
 description = "Big Straight as little straight"
-include = true
 
 [c1fa0a3a-40ba-4153-a42d-32bc34d2521e]
 description = "No pairs but not a big straight"
-include = true
 
 [207e7300-5d10-43e5-afdd-213e3ac8827d]
 description = "Choice"
-include = true
 
 [b524c0cf-32d2-4b40-8fb3-be3500f3f135]
 description = "Yacht as choice"
-include = true

--- a/exercises/practice/zipper/.meta/tests.toml
+++ b/exercises/practice/zipper/.meta/tests.toml
@@ -4,52 +4,39 @@
 
 [771c652e-0754-4ef0-945c-0675d12ef1f5]
 description = "data is retained"
-include = true
 
 [d7dcbb92-47fc-4d01-b81a-df3353bc09ff]
 description = "left, right and value"
-include = true
 
 [613d8286-b05c-4453-b205-e6f9c5966339]
 description = "dead end"
-include = true
 
 [dda31af7-1c68-4e29-933a-c9d198d94284]
 description = "tree from deep focus"
-include = true
 
 [1e3072a6-f85b-430b-b014-cdb4087e3577]
 description = "traversing up from top"
-include = true
 
 [b8505f6a-aed4-4c2e-824f-a0ed8570d74b]
 description = "left, right, and up"
-include = true
 
 [47df1a27-b709-496e-b381-63a03b82ea5f]
 description = "set_value"
-include = true
 
 [16a1f1a8-dbed-456d-95ac-1cbb6093e0ab]
 description = "set_value after traversing up"
-include = true
 
 [535a91af-a02e-49cd-8d2c-ecb6e4647174]
 description = "set_left with leaf"
-include = true
 
 [b3f60c4b-a788-4ffd-be5d-1e69aee61de3]
 description = "set_right with null"
-include = true
 
 [e91c221d-7b90-4604-b4ec-46638a673a12]
 description = "set_right with subtree"
-include = true
 
 [c246be85-6648-4e9c-866f-b08cd495149a]
 description = "set_value on deep focus"
-include = true
 
 [47aa85a0-5240-48a4-9f42-e2ac636710ea]
 description = "different paths to same zipper"
-include = true


### PR DESCRIPTION
This PR simplifies the `tests.toml` files by removing any `include = true` properties, which are redundant as the default value of this field is `true`.

As the vast majority of the test cases use `include = true`, omitting it makes the `tests.toml` files more readable and make the exceptional cases (`include = false`) easier to identify.

We've updated `configlet` to use this new behavior. See https://github.com/exercism/configlet/issues/186 and https://github.com/exercism/configlet/issues/207 for the corresponding discussion.

## Tracking

https://github.com/exercism/v3-launch/issues/31
