### PR TITLE
🤖 Update name of `dnd-character` exercise

### DIFF
--- a/config.json
+++ b/config.json
@@ -1492,7 +1492,7 @@
       },
       {
         "slug": "dnd-character",
-        "name": "Dnd Character",
+        "name": "D&D Character",
         "uuid": "32b87799-0e4d-471f-ae22-e5a9dbbdf7b3",
         "practices": [],
         "prerequisites": [],


### PR DESCRIPTION
This PR correct the name of the `dnd-character` exercise to its correct value: "D&D Character"