### PR TITLE
Add missing testHelpers to hello-world

### DIFF
--- a/exercises/practice/hello-world/hello-world.test
+++ b/exercises/practice/hello-world/hello-world.test
@@ -1,7 +1,9 @@
 #!/usr/bin/env tclsh
 package require tcltest
 namespace import ::tcltest::*
+source testHelpers.tcl
 
+############################################################
 source "hello-world.tcl"
 
 test hello-1 "Say Hi!" -body {

--- a/exercises/practice/hello-world/testHelpers.tcl
+++ b/exercises/practice/hello-world/testHelpers.tcl
@@ -1,0 +1,20 @@
+#############################################################
+# Override some tcltest procs with additional functionality
+
+# Allow an environment variable to override `skip`
+proc skip {patternList} {
+    if { [info exists ::env(RUN_ALL)]
+         && [string is boolean -strict $::env(RUN_ALL)]
+         && $::env(RUN_ALL)
+    } then return else {
+        uplevel 1 [list ::tcltest::skip $patternList]
+    }
+}
+
+# Exit non-zero if any tests fail.
+# The cleanupTests resets the numTests array, so capture it first.
+proc cleanupTests {} {
+    set failed [expr {$::tcltest::numTests(Failed) > 0}]
+    uplevel 1 ::tcltest::cleanupTests
+    if {$failed} then {exit 1}
+}


### PR DESCRIPTION
I believe the lack of this file in this one exercise is what causes the test runner to always report success.