### PR TITLE
instructions.append needs a header that is not removed

### DIFF
--- a/exercises/practice/hangman/.docs/instructions.append.md
+++ b/exercises/practice/hangman/.docs/instructions.append.md
@@ -1,4 +1,6 @@
-# New approach to the exercise
+# heading to be removed
+
+## New approach to the exercise
 
 Please ignore the part regarding an FRP library, a third party library is
 not required for this exercise.  This exercise focuses on event-driven
@@ -8,7 +10,7 @@ You are required to construct a TCP server and a domain-specific protocol.
 This server is launched with the word to guess.  The test script implements
 the client that sends commands to the server.
 
-## Domain-specific protocol
+### Domain-specific protocol
 
 The protocol commands to implement are:
 
@@ -25,7 +27,7 @@ The protocol commands to implement are:
 
 The server should be able to handle these commands case-insensitively.
 
-## What port does the server use?
+### What port does the server use?
 
 Start your server using **port number 0**: Tcl will find an unused port, so
 we don't have to hardcode a port number in the test script.  All
@@ -34,7 +36,7 @@ environment, so the server can communicate its port back to the test script
 using the global `env` array. There's an example in the initial hangman.tcl
 file.
 
-## Hints
+### Hints
 
 You'll need these Tcl commands:
 [`socket`](https://www.tcl-lang.org/man/tcl8.6/TclCmd/socket.htm),


### PR DESCRIPTION
It looks like the h1 header in the instructions.appends is stripped before the file is concatenated with the instructions.

This one definitely needs a heading in between: the oval is where the appends file starts
![image](https://user-images.githubusercontent.com/122470/138383330-f3158cfc-6d77-44e7-96a0-a15942016cd9.png)
