### PR TITLE
Normalize practice exercise names

### DIFF
--- a/config.json
+++ b/config.json
@@ -274,7 +274,7 @@
       },
       {
         "slug": "rna-transcription",
-        "name": "Rna Transcription",
+        "name": "RNA Transcription",
         "uuid": "1479aec4-6f8f-403e-ad0b-33d0b7b7891a",
         "practices": [],
         "prerequisites": [],
@@ -411,7 +411,7 @@
       },
       {
         "slug": "difference-of-squares",
-        "name": "Difference Of Squares",
+        "name": "Difference of Squares",
         "uuid": "294e0af9-436a-4d0e-be87-d1da7df16a08",
         "practices": [],
         "prerequisites": [],
@@ -422,7 +422,7 @@
       },
       {
         "slug": "sum-of-multiples",
-        "name": "Sum Of Multiples",
+        "name": "Sum of Multiples",
         "uuid": "5c0669b7-244c-4924-ba43-77e835f1ceed",
         "practices": [],
         "prerequisites": [],
@@ -542,7 +542,7 @@
       },
       {
         "slug": "etl",
-        "name": "Etl",
+        "name": "ETL",
         "uuid": "ddaa2182-2d73-4599-a300-2f0e887dc4d5",
         "practices": [],
         "prerequisites": [],
@@ -797,7 +797,7 @@
       },
       {
         "slug": "run-length-encoding",
-        "name": "Run Length Encoding",
+        "name": "Run-Length Encoding",
         "uuid": "1597d6c8-f695-4566-8f76-656d026ecc0a",
         "practices": [],
         "prerequisites": [],
@@ -1272,7 +1272,7 @@
       },
       {
         "slug": "pascals-triangle",
-        "name": "Pascals Triangle",
+        "name": "Pascal's Triangle",
         "uuid": "935a5e4d-389d-44b1-a069-a8a5ac6d3357",
         "practices": [],
         "prerequisites": [],
@@ -1326,7 +1326,7 @@
       },
       {
         "slug": "isbn-verifier",
-        "name": "Isbn Verifier",
+        "name": "ISBN Verifier",
         "uuid": "e7bf5f8f-ed1b-480d-9de9-2e666a21b08f",
         "practices": [],
         "prerequisites": [],
@@ -1387,7 +1387,7 @@
       },
       {
         "slug": "ocr-numbers",
-        "name": "Ocr Numbers",
+        "name": "OCR Numbers",
         "uuid": "2ba0b786-757f-454a-b7cc-9434fc6666f0",
         "practices": [],
         "prerequisites": [],
@@ -1433,7 +1433,7 @@
       },
       {
         "slug": "rest-api",
-        "name": "Rest Api",
+        "name": "REST API",
         "uuid": "c85d2acd-c6b3-4005-9e02-bef1d24fddbf",
         "practices": [],
         "prerequisites": [],
@@ -1455,7 +1455,7 @@
       },
       {
         "slug": "pov",
-        "name": "Pov",
+        "name": "POV",
         "uuid": "7eec8ce4-9acd-441e-92fb-23b6ee1c872a",
         "practices": [],
         "prerequisites": [],
@@ -1481,7 +1481,7 @@
       },
       {
         "slug": "diffie-hellman",
-        "name": "Diffie Hellman",
+        "name": "Diffie-Hellman",
         "uuid": "86a7b350-9929-419d-9dda-c3dd98588479",
         "practices": [],
         "prerequisites": [],
@@ -1554,7 +1554,7 @@
       },
       {
         "slug": "dot-dsl",
-        "name": "Dot Dsl",
+        "name": "DOT DSL",
         "uuid": "957b5108-1c4e-475a-8953-2aeb98465b1d",
         "practices": [],
         "prerequisites": [],


### PR DESCRIPTION
We have added explicit exercise titles to the metadata.toml
files in problem-specifications.

This updates the exercise names to match the values
in this field.


Ref: https://github.com/exercism/exercism/issues/6579