### PR TITLE
Sync largest-series-product docs with problem-specifications

### DIFF
--- a/exercises/practice/largest-series-product/.meta/tests.toml
+++ b/exercises/practice/largest-series-product/.meta/tests.toml
@@ -41,9 +41,11 @@ description = "rejects span longer than string length"
 
 [06bc8b90-0c51-4c54-ac22-3ec3893a079e]
 description = "reports 1 for empty string and empty product (0 span)"
+include = false
 
 [3ec0d92e-f2e2-4090-a380-70afee02f4c0]
 description = "reports 1 for nonempty string and empty product (0 span)"
+include = false
 
 [6d96c691-4374-4404-80ee-2ea8f3613dd4]
 description = "rejects empty string and nonzero span"

--- a/exercises/practice/largest-series-product/largest-series-product.test
+++ b/exercises/practice/largest-series-product/largest-series-product.test
@@ -53,17 +53,6 @@ test lsp-1.9 "reports zero if all spans include zero" -body {
     largestSeriesProduct "99099" 3
 } -returnCodes ok -result 0
 
-skip lsp-1.10
-test lsp-1.10 "reports 1 for empty string and empty product (0 span)" -body {
-    largestSeriesProduct "" 0
-} -returnCodes ok -result 1
-
-skip lsp-1.11
-test lsp-1.11 "reports 1 for nonempty string and empty product (0 span)" -body {
-    largestSeriesProduct "123" 0
-} -returnCodes ok -result 1
-
-
 skip lsp-2.1
 test lsp-2.1 "rejects span longer than string length" -body {
     largestSeriesProduct "123" 4 


### PR DESCRIPTION
The largest-series-product exercise has been overhauled as part of a project to make practice exercises more consistent and friendly.

For more context, please see the discussion in the forum, as well as the pull request that updated the exercise in the problem-specifications repository:

- https://forum.exercism.org/t/new-project-making-practice-exercises-more-consistent-and-human-across-exercism/3943
- https://github.com/exercism/problem-specifications/pull/2246 


Note that we have deprecated and removed two test cases that deal with the multiplicative identity (also referred to as an empty product). By doing this we were able to avoid talking about this at all, which makes this exercise much more approachable.

----

If you approve this pull request, I will eventually merge it. However, if you are happy with this change **please merge the pull request**, as it will get the changes into the hands of the students much more quickly.

If this pull request contradicts the exercise on your track, **please add a review with _request changes_**. This will block the pull request from getting merged.

Otherwise, as discussed in the forum post linked to above, we aim to take an optimistic merging approach.

If you wish to suggest tweaks to these changes, please open a pull request to the exercism/problem-specifications repository to discuss, so that everyone who has an interest in the shared exercise descriptions can participate.

