### PR TITLE
Remove `file exists` and `file readable` tests.

### DIFF
--- a/exercises/practice/dot-dsl/dot-dsl.test
+++ b/exercises/practice/dot-dsl/dot-dsl.test
@@ -296,20 +296,4 @@ test dot-2.9 "non-alphanumeric node name" -setup {
     file delete $filename
 } -returnCodes error -result {node name must be alphanumeric}
 
-skip dot-2.10
-test dot-2.10 "non-existent file" -body {
-    set filename [createTempFile ""]
-    file delete $filename
-    processDotFile $filename
-} -returnCodes error -result {cannot read file}
-
-skip dot-2.11
-test dot-2.11 "unreadable file" -body {
-    set filename [createTempFile ""]
-    file attributes $filename -permissions "a-r"
-    processDotFile $filename
-} -cleanup {
-    file delete $filename
-} -returnCodes error -result {cannot read file}
-
 cleanupTests


### PR DESCRIPTION
It seems that the docker filesystem, files are always readable? Test 2.11 passes locally but fails in the test runner: the tcl command `[file readable $filename]` returns true even when read permissions are explicitly removed. The tests removed in this commit don't alter the meaning of the exercise, they are just validation tests.