### PR TITLE
arg, I forgot to include the destination of a link

### DIFF
--- a/exercises/practice/leap/.articles/performance/content.md
+++ b/exercises/practice/leap/.articles/performance/content.md
@@ -79,3 +79,4 @@ leap_clock
 [approach-boolean-chain]: /tracks/tcl/exercises/leap/approaches/boolean-chain
 [approach-ternary-operator]: /tracks/tcl/exercises/leap/approaches/ternary-operator
 [approach-clock-command]: /tracks/tcl/exercises/leap/approaches/clock-command
+[time-command]: https://tcl.tk/man/tcl8.6/TclCmd/time.htm


### PR DESCRIPTION
Sorry @ErikSchierboom for the tiny PRs to fix my mistakes.

https://exercism.org/tracks/tcl/exercises/leap/articles/performance

![image](https://github.com/exercism/tcl/assets/122470/29a669a0-0df0-4f0b-a0be-c07b6b57a20c)
