### PR TITLE
un-deprecate reverse-string

### DIFF
--- a/config.json
+++ b/config.json
@@ -338,7 +338,6 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 2,
-        "status": "deprecated",
         "topics": [
           "strings"
         ]

--- a/exercises/practice/reverse-string/.docs/instructions.append.md
+++ b/exercises/practice/reverse-string/.docs/instructions.append.md
@@ -1,0 +1,10 @@
+# ignore
+
+## Tcl-specific instructions
+
+There are a couple of builtin commands that make this exercise trivial:
+
+* [`string reverse`](https://www.tcl.tk/man/tcl/TclCmd/string.htm#M43)
+* [`lreverse`](https://www.tcl.tk/man/tcl/TclCmd/lreverse.html)
+
+Try to implement this yourself without using those "cheats".

--- a/exercises/practice/reverse-string/.meta/config.json
+++ b/exercises/practice/reverse-string/.meta/config.json
@@ -2,9 +2,6 @@
   "authors": [
     "glennj"
   ],
-  "contributors": [
-    "sshine"
-  ],
   "files": {
     "solution": [
       "reverse-string.tcl"

--- a/exercises/practice/reverse-string/.meta/deprecated.md
+++ b/exercises/practice/reverse-string/.meta/deprecated.md
@@ -1,5 +1,0 @@
-# Deprecated
-
-This exercise is deprecated as being too easy: it will not help user's
-fluency in Tcl by reimplementing this basic builtin command
-([string reverse](https://tcl.tk/man/tcl8.6/TclCmd/string.htm#M43)).

--- a/exercises/practice/reverse-string/.meta/example.tcl
+++ b/exercises/practice/reverse-string/.meta/example.tcl
@@ -1,7 +1,8 @@
-proc stringReverse {str} {
-    set rev ""
-    for {set i [expr {[string length $str] - 1}]} {$i >= 0} {incr i -1} {
-        append rev [string range $str $i $i]
+proc reverse {input {reversed ""}} {
+    if {$input eq ""} {
+        return $reversed
     }
-    return $rev
+    tailcall reverse \
+        [string range $input 1 end] \
+        [string cat [string index $input 0] $reversed]
 }

--- a/exercises/practice/reverse-string/.meta/tests.toml
+++ b/exercises/practice/reverse-string/.meta/tests.toml
@@ -1,6 +1,13 @@
-# This is an auto-generated file. Regular comments will be removed when this
-# file is regenerated. Regenerating will not touch any manually added keys,
-# so comments can be added in a "comment" key.
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
 
 [c3b7d806-dced-49ee-8543-933fd1719b1c]
 description = "an empty string"
@@ -19,3 +26,16 @@ description = "a palindrome"
 
 [b9e7dec1-c6df-40bd-9fa3-cd7ded010c4c]
 description = "an even-sized word"
+
+[1bed0f8a-13b0-4bd3-9d59-3d0593326fa2]
+description = "wide characters"
+
+[93d7e1b8-f60f-4f3c-9559-4056e10d2ead]
+description = "grapheme cluster with pre-combined form"
+include = false
+comment = "Tcl 8.x does not implement Unicode fully"
+
+[1028b2c1-6763-4459-8540-2da47ca512d9]
+description = "grapheme clusters"
+include = false
+comment = "Tcl 8.x does not implement Unicode fully"

--- a/exercises/practice/reverse-string/reverse-string.tcl
+++ b/exercises/practice/reverse-string/reverse-string.tcl
@@ -1,4 +1,3 @@
-proc stringReverse {} {
+proc reverse {input} {
     throw {NOT_IMPLEMENTED} "Implement this procedure."
-    # Stay away from [string reverse] please.
 }

--- a/exercises/practice/reverse-string/reverse-string.test
+++ b/exercises/practice/reverse-string/reverse-string.test
@@ -7,32 +7,37 @@ source testHelpers.tcl
 source "reverse-string.tcl"
 
 test reverse-string-1 "an empty string" -body {
-    stringReverse ""
+    reverse ""
 } -returnCodes ok -result ""
 
 skip reverse-string-2
 test reverse-string-2 "a word" -body {
-    stringReverse "robot"
+    reverse "robot"
 } -returnCodes ok -result "tobor"
 
 skip reverse-string-3
 test reverse-string-3 "a capitalized word" -body {
-    stringReverse "Ramen"
+    reverse "Ramen"
 } -returnCodes ok -result "nemaR"
 
 skip reverse-string-4
 test reverse-string-4 "a sentence with punctuation" -body {
-    stringReverse "I'm hungry!"
+    reverse "I'm hungry!"
 } -returnCodes ok -result "!yrgnuh m'I"
 
 skip reverse-string-5
 test reverse-string-5 "a palindrome" -body {
-    stringReverse "racecar"
+    reverse "racecar"
 } -returnCodes ok -result "racecar"
 
 skip reverse-string-6
 test reverse-string-6 "an even-sized word" -body {
-    stringReverse "drawer"
+    reverse "drawer"
 } -returnCodes ok -result "reward"
+
+skip reverse-string-7
+test reverse-string-7 "wide characters" -body {
+    reverse "子猫"
+} -returnCodes ok -result "猫子"
 
 cleanupTests


### PR DESCRIPTION
This was deprecated as too easy, but easy is in the eyes of the beholder.