### PR TITLE
Format all `instructions.append.md` to start with an H1 (required but ignored) and H2

### DIFF
--- a/exercises/practice/accumulate/.docs/instructions.append.md
+++ b/exercises/practice/accumulate/.docs/instructions.append.md
@@ -1,6 +1,5 @@
-# Hints
+# Instructions append
 
-You'll need to use the [uplevel](https://tcl.tk/man/tcl8.6/TclCmd/upvar.htm)
-and [upvar](https://tcl.tk/man/tcl8.6/TclCmd/upvar.htm) commands for this
-exercise.
+## Hints
 
+You'll need to use the [uplevel](https://tcl.tk/man/tcl8.6/TclCmd/upvar.htm) and [upvar](https://tcl.tk/man/tcl8.6/TclCmd/upvar.htm) commands for this exercise.

--- a/exercises/practice/anagram/.docs/instructions.append.md
+++ b/exercises/practice/anagram/.docs/instructions.append.md
@@ -1,3 +1,5 @@
 # Instructions Append
 
+## Implementation
+
 You must return the anagrams in the same order as they are listed in the candidate words.

--- a/exercises/practice/complex-numbers/.docs/instructions.append.md
+++ b/exercises/practice/complex-numbers/.docs/instructions.append.md
@@ -1,5 +1,6 @@
-# Implementing functions for the `expr` command
+# Instructions append
+
+## Implementing functions for the `expr` command
 
 Some of these tests require you to create new functions for the `expr` command.
-Read the Tcl [mathfunc](https://www.tcl-lang.org/man/tcl8.6/TclCmd/mathfunc.htm)
-documentation to learn how.
+Read the Tcl [mathfunc](https://www.tcl-lang.org/man/tcl8.6/TclCmd/mathfunc.htm) documentation to learn how.

--- a/exercises/practice/dot-dsl/.docs/instructions.append.md
+++ b/exercises/practice/dot-dsl/.docs/instructions.append.md
@@ -1,4 +1,6 @@
-# DOT Language Spec
+# Instructions append
+
+## DOT Language Spec
 
 Although the DOT language has a [formal specification][DOT-spec], the tests for this exercise do not expect the full specification to be implemented.
 
@@ -6,4 +8,3 @@ The Tcl wiki has [some notes about domain-specific languages][DSL-wiki].
 
 [DOT-spec]: https://www.graphviz.org/doc/info/lang.html
 [DSL-wiki]: https://wiki.tcl-lang.org/page/domain-specific+language
-

--- a/exercises/practice/error-handling/.docs/instructions.append.md
+++ b/exercises/practice/error-handling/.docs/instructions.append.md
@@ -1,4 +1,5 @@
-# Resources
+# Instructions append
 
-The Tcl Wiki entry on [Errors management](https://wiki.tcl-lang.org/page/Errors+management)
-is useful for this exercise.
+## Resources
+
+The Tcl Wiki entry on [Errors management](https://wiki.tcl-lang.org/page/Errors+management) is useful for this exercise.

--- a/exercises/practice/gigasecond/.docs/instructions.append.md
+++ b/exercises/practice/gigasecond/.docs/instructions.append.md
@@ -1,5 +1,7 @@
-# placeholder
+# Instructions append
 
-To solve this exercise in Tcl, you'll need to use [the `clock` command][clock]
+## Implementation
+
+To solve this exercise in Tcl, you'll need to use [the `clock` command][clock].
 
 [clock]: https://www.tcl-lang.org/man/tcl8.6/TclCmd/clock.htm

--- a/exercises/practice/list-ops/.docs/instructions.append.md
+++ b/exercises/practice/list-ops/.docs/instructions.append.md
@@ -1,26 +1,34 @@
-# The Tcl `apply` command
+# Instructions append
 
-The test cases may look confusing. You are expected to implement this: 
+## The Tcl `apply` command
+
+The test cases may look confusing.
+You are expected to implement this: 
+
 ```tcl
 set myList {alpha beta gamma delta}
 listOps::filter $myList {{word} {expr {[string length $word] == 4}}
 ```
+
 Why does that last argument have so many braces?
 
 Recall that the `proc` command is defined as:
+
 ```tcl
 proc procName argList body
 ```
 
 Tcl has an `apply` command:
+
 ```tcl
 apply func ?arg1 arg2 ...?
 ```
-this "func" is a two element list `{argList body}` that is essentially an
-anonymous proc (or "lambda"). The `apply` command invokes that anonymous
-proc, passing it the arguments it needs.
+
+this "func" is a two element list `{argList body}` that is essentially an anonymous proc (or "lambda").
+The `apply` command invokes that anonymous proc, passing it the arguments it needs.
 
 As an example, these are equivalent:
+
 ```tcl
 # using proc
 proc myReverse {str} {return [string reverse $str]}
@@ -33,7 +41,7 @@ puts [apply {{str} {string reverse $str}} "Hello, World!"]
 set func {{str} {string reverse $str}}
 puts [apply $func "Hello, World!"]
 ```
+
 Using `apply` makes it simpler to pass around blocks of code.
 
-Ref: [`apply`](https://tcl.tk/man/tcl8.6/TclCmd/apply.htm),
-[`proc`](https://tcl.tk/man/tcl8.6/TclCmd/proc.htm).
+Ref: [`apply`](https://tcl.tk/man/tcl8.6/TclCmd/apply.htm), [`proc`](https://tcl.tk/man/tcl8.6/TclCmd/proc.htm).

--- a/exercises/practice/zebra-puzzle/.docs/instructions.append.md
+++ b/exercises/practice/zebra-puzzle/.docs/instructions.append.md
@@ -1,4 +1,6 @@
-# Tcl Packages
+# Instructions append
+
+## Tcl Packages
 
 This is the first exercise to include a pre-written package.
 Note the presence of the file `pkgIndex.tcl` and the inclusion of the current directory in the `auto_path` variable.

--- a/exercises/practice/zipper/.docs/instructions.append.md
+++ b/exercises/practice/zipper/.docs/instructions.append.md
@@ -1,3 +1,6 @@
-# Scope
+# Instructions append
 
-You'll find a Tree class already implemented for you. Your task is to write the Zipper class.
+## Scope
+
+You'll find a Tree class already implemented for you.
+Your task is to write the Zipper class.


### PR DESCRIPTION
See related discussions [here](https://forum.exercism.org/t/grep-instructions-append-may-need-a-visible-header/53923) as well as https://github.com/exercism/docs/pull/592. Append files should all have an H1. Including an H2 helps break the flow from the non-append file to the append file so it does not read as the same stream of thought.